### PR TITLE
Remove teft-theme dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ public/content/languages
 public/content/plugins
 public/content/mu-plugins/wp-resets
 
-# Themes
-public/content/themes/teft-theme
-
 # Upgrade and uploads
 public/content/upgrade
 public/content/uploads

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "symfony/dotenv": "5.1.4",
     "inpsyde/wp-translation-downloader": "1.1.3",
     "dekode/wp-resets": "2.0.0",
-    "teft/teft-cards": "2.5.0",
-    "teft/teft-theme": "1.0.4"
+    "teft/teft-cards": "2.5.0"
   },
   "require-dev": {
     "dekode/coding-standards": "3.4.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,5 +9,4 @@
 	<exclude-pattern>public/content/languages</exclude-pattern>
 	<exclude-pattern>public/content/plugins</exclude-pattern>
 	<exclude-pattern>public/content/uploads</exclude-pattern>
-	<exclude-pattern>public/content/themes/teft-theme</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Remove confusing Teft theme dependency. New Teft projects should pull the latest [theme source from the Teft repo](https://github.com/DekodeInteraktiv/teft/tree/master/themes/teft-theme).