### PR TITLE
Check for boolean as string 'false', '0', 'true' and '1'

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -109,7 +109,7 @@ define( 'DISALLOW_FILE_EDIT', true );
 if ( env( 'WP_ALLOW_MULTISITE' ) ) {
 	define( 'WP_ALLOW_MULTISITE', true );
 	define( 'MULTISITE', true );
-	define( 'SUBDOMAIN_INSTALL', env( 'SUBDOMAIN_INSTALL' ) ?: false );
+	define( 'SUBDOMAIN_INSTALL', filter_var( env( 'SUBDOMAIN_INSTALL' ), FILTER_VALIDATE_BOOLEAN ) ?: false );
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 	define( 'DOMAIN_CURRENT_SITE', env( 'DOMAIN_CURRENT_SITE' ) ?: parse_url( WP_HOME, PHP_URL_HOST ) );
 	define( 'PATH_CURRENT_SITE', '/' );


### PR DESCRIPTION
Using false in .env for `SUBDOMAIN_INSTALL` did not work, since it interpreted the value as string 'false' and set true for the constant