### PR TITLE
Add anonymization config and related PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- The following is a recommended collection of information to include in any Pull Request, please fill it in to the best of your abilities. -->
+
+## Short introduction
+<!-- Describe what this Pull Request achieves, this is your elevator pitch. -->
+
+## Description
+<!-- A more thurough description of the problem you are solving, how you solve it, and why. -->
+
+## Steps to test / reproduce
+<!-- Provide details on how to test your changes, or reproduce the issue they resolve. -->
+
+## Screenshots
+<!-- Include any relevant screenshots or screen captures showing off how these changes affect the project, if they are visual changes (before and after views are great, and help speed uip the review process) -->
+
+## Checklist
+- [ ] I have written unit tests where applicable
+- [ ] My code follows the Dekode coding standards
+- [ ] I've tested my changes with keyboard and screen readers
+- [ ] My code follows the accessibility standards
+- [ ] My code is properly documented
+- [ ] I've declared any PII (Personally Identifiable Information) for anonymization

--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ Any custom made wp-cli commands which communicate with the third party, should b
 
 ## Cronjobs
 List all non-standard cronjobs on the site and say a few words about the purpose of each of them.
+
+## Anonymization
+Project data is anonymized using a config file, `anonymize.config.json`, where the developer is expected to declare any Personally Identifiable Information (PII) for the project in a data structure relating to database tables and entries.
+
+This anonymization is performed using the [anonymize-mysqldump project](https://github.com/humanmade/go-anonymize-mysqldump), where you can also see the [structure of the config file](https://github.com/humanmade/go-anonymize-mysqldump#config-file).
+
+The default configuration file provides support for a vanilla WordPress installation, with just data relating to comment sand usermeta accounted for.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Project data is anonymized using a config file, `anonymize.config.json`, where t
 
 This anonymization is performed using the [anonymize-mysqldump project](https://github.com/humanmade/go-anonymize-mysqldump), where you can also see the [structure of the config file](https://github.com/humanmade/go-anonymize-mysqldump#config-file).
 
-The default configuration file provides support for a vanilla WordPress installation, with just data relating to comment sand usermeta accounted for.
+The default configuration file provides support for a vanilla WordPress installation, with just data relating to comments and usermeta accounted for.

--- a/anonymize.config.json
+++ b/anonymize.config.json
@@ -1,0 +1,127 @@
+{
+	"patterns": [
+		{
+			"tableName": "wp_users",
+			"fields": [
+				{
+					"field": "user_login",
+					"position": 2,
+					"type": "username",
+					"constraints": null
+				},
+				{
+					"field": "user_pass",
+					"position": 3,
+					"type": "password",
+					"constraints": null
+				},
+				{
+					"field": "user_nicename",
+					"position": 4,
+					"type": "username",
+					"constraints": null
+				},
+				{
+					"field": "user_email",
+					"position": 5,
+					"type": "email",
+					"constraints": null
+				},
+				{
+					"field": "user_url",
+					"position": 6,
+					"type": "url",
+					"constraints": null
+				},
+				{
+					"field": "display_name",
+					"position": 10,
+					"type": "name",
+					"constraints": null
+				}
+			]
+		},
+		{
+			"tableName": "wp_usermeta",
+			"fields": [
+				{
+					"field": "meta_value",
+					"position": 4,
+					"type": "firstName",
+					"constraints": [
+						{
+							"field": "meta_key",
+							"position": 3,
+							"value": "first_name"
+						}
+					]
+				},
+				{
+					"field": "meta_value",
+					"position": 4,
+					"type": "lastName",
+					"constraints": [
+						{
+							"field": "meta_key",
+							"position": 3,
+							"value": "last_name"
+						}
+					]
+				},
+				{
+					"field": "meta_value",
+					"position": 4,
+					"type": "firstName",
+					"constraints": [
+						{
+							"field": "meta_key",
+							"position": 3,
+							"value": "nickname"
+						}
+					]
+				},
+				{
+					"field": "meta_value",
+					"position": 4,
+					"type": "paragraph",
+					"constraints": [
+						{
+							"field": "meta_key",
+							"position": 3,
+							"value": "description"
+						}
+					]
+				}
+			]
+		},
+		{
+			"tableName": "wp_comments",
+			"fields": [
+				{
+					"field": "comment_author",
+					"position": 3,
+					"type": "username",
+					"constraints": null
+				},
+				{
+					"field": "comment_author_email",
+					"position": 4,
+					"type": "email",
+					"constraints": null
+				},
+				{
+					"field": "comment_author_url",
+					"position": 5,
+					"type": "url",
+					"constraints": null
+				},
+				{
+					"field": "comment_author_IP",
+					"position": 6,
+					"type": "ipv4",
+					"constraints": null
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This provides a default config file for using the [mysqldump-anonymizer from HumanMade](https://github.com/humanmade/go-anonymize-mysqldump), allowing us to quickly anonymize database dumps on the fly when requested.

It also introduces a Pull Request template to the mix, with some common fields to help speed up reviews inside projects (we will likely want to just ignore it when writing requests for project base it self), as well as a checklist of fields. This was inspired by the Teft PR template, and was primarily added to ensure a checklist item for declaring PII (Personally Identifiable Information) was added as a reminder when devs create PRs for new features.

We may expand on the anonymizer default config in the future, but the current setup handles vanilla WordPress installs, and should work out of the box in most cases.