### PR TITLE
Add browsersync webpack plugin to dev dependency / Extend configurati…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ NONCE_SALT='generateme'
 DISABLE_WP_CRON=false
 
 # Webpack BrowserSync
+#BROWSER_SYNC_ENABLE=true
 #BROWSER_SYNC_PROXY=https://sitename.local
 #BROWSER_SYNC_PORT=3003
 #BROWSER_SYNC_HTTPS=true

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,8 @@ NONCE_SALT='generateme'
 
 # Disable WP Cron
 DISABLE_WP_CRON=false
+
+# Webpack BrowserSync
+#BROWSER_SYNC_PROXY=https://sitename.local
+#BROWSER_SYNC_PORT=3003
+#BROWSER_SYNC_HTTPS=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2910,6 +2910,32 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				},
+				"puppeteer": {
+					"version": "npm:puppeteer-core@3.0.0",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+					"dev": true,
+					"requires": {
+						"@types/mime-types": "^2.1.0",
+						"debug": "^4.1.0",
+						"extract-zip": "^2.0.0",
+						"https-proxy-agent": "^4.0.0",
+						"mime": "^2.0.3",
+						"mime-types": "^2.1.25",
+						"progress": "^2.0.1",
+						"proxy-from-env": "^1.0.0",
+						"rimraf": "^3.0.2",
+						"tar-fs": "^2.0.0",
+						"unbzip2-stream": "^1.3.3",
+						"ws": "^7.2.3"
+					}
+				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -2929,6 +2955,15 @@
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"strip-bom": {
@@ -3019,6 +3054,12 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+			"dev": true
+		},
+		"after": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
 			"dev": true
 		},
 		"agent-base": {
@@ -3263,6 +3304,12 @@
 				"es-abstract": "^1.18.0-next.1"
 			}
 		},
+		"arraybuffer.slice": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+			"dev": true
+		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -3365,6 +3412,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"async-each-series": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+			"integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+			"dev": true
+		},
 		"async-limiter": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -3423,6 +3476,15 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
 			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.10.0"
+			}
 		},
 		"axobject-query": {
 			"version": "2.2.0",
@@ -3598,6 +3660,12 @@
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+			"dev": true
+		},
 		"bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -3665,10 +3733,28 @@
 				}
 			}
 		},
+		"base64-arraybuffer": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+			"dev": true
+		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
+		},
+		"base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"dev": true
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -3724,6 +3810,12 @@
 				"inherits": "^2.0.4",
 				"readable-stream": "^3.4.0"
 			}
+		},
+		"blob": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -3868,6 +3960,171 @@
 				}
 			}
 		},
+		"browser-sync": {
+			"version": "2.26.14",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.14.tgz",
+			"integrity": "sha512-3TtpsheGolJT6UFtM2CZWEcGJmI4ZEvoCKiKE2bvcDnPxRkhQT4nIGVtfiyPcoHKXGM0LwMOZmYJNWfiNfVXWA==",
+			"dev": true,
+			"requires": {
+				"browser-sync-client": "^2.26.14",
+				"browser-sync-ui": "^2.26.14",
+				"bs-recipes": "1.3.4",
+				"bs-snippet-injector": "^2.0.1",
+				"chokidar": "^3.5.1",
+				"connect": "3.6.6",
+				"connect-history-api-fallback": "^1",
+				"dev-ip": "^1.0.1",
+				"easy-extender": "^2.3.4",
+				"eazy-logger": "3.1.0",
+				"etag": "^1.8.1",
+				"fresh": "^0.5.2",
+				"fs-extra": "3.0.1",
+				"http-proxy": "^1.18.1",
+				"immutable": "^3",
+				"localtunnel": "^2.0.1",
+				"micromatch": "^4.0.2",
+				"opn": "5.3.0",
+				"portscanner": "2.1.1",
+				"qs": "6.2.3",
+				"raw-body": "^2.3.2",
+				"resp-modifier": "6.0.2",
+				"rx": "4.1.0",
+				"send": "0.16.2",
+				"serve-index": "1.9.1",
+				"serve-static": "1.13.2",
+				"server-destroy": "1.0.1",
+				"socket.io": "2.4.0",
+				"ua-parser-js": "^0.7.18",
+				"yargs": "^15.4.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+					"integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+					"dev": true
+				},
+				"send": {
+					"version": "0.16.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
+					}
+				},
+				"serve-static": {
+					"version": "1.13.2",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+					"dev": true,
+					"requires": {
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
+						"send": "0.16.2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"dev": true
+				}
+			}
+		},
+		"browser-sync-client": {
+			"version": "2.26.14",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.14.tgz",
+			"integrity": "sha512-be0m1MchmKv/26r/yyyolxXcBi052aYrmaQep5nm8YNMjFcEyzv0ZoOKn/c3WEXNlEB/KeXWaw70fAOJ+/F1zQ==",
+			"dev": true,
+			"requires": {
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"mitt": "^1.1.3",
+				"rxjs": "^5.5.6"
+			}
+		},
+		"browser-sync-ui": {
+			"version": "2.26.14",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.14.tgz",
+			"integrity": "sha512-6oT1sboM4KVNnWCCJDMGbRIeTBw97toMFQ+srImvwQ6J5t9KMgizaIX8HcKLiemsUMSJkgGM9RVKIpq2UblgOA==",
+			"dev": true,
+			"requires": {
+				"async-each-series": "0.1.1",
+				"connect-history-api-fallback": "^1",
+				"immutable": "^3",
+				"server-destroy": "1.0.1",
+				"socket.io-client": "^2.4.0",
+				"stream-throttle": "^0.1.3"
+			}
+		},
+		"browser-sync-webpack-plugin": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/browser-sync-webpack-plugin/-/browser-sync-webpack-plugin-2.3.0.tgz",
+			"integrity": "sha512-MDvuRrTCtoL11dTdwMymo9CNJvYxJoW67gOO61cThfzHNX40S5WcBU+0bVQ86ll7r7aNpNgyzxF7RtnXMTDbyA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4"
+			}
+		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -3961,6 +4218,18 @@
 				"escalade": "^3.1.1",
 				"node-releases": "^1.1.69"
 			}
+		},
+		"bs-recipes": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+			"integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
+			"dev": true
+		},
+		"bs-snippet-injector": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+			"integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+			"dev": true
 		},
 		"bser": {
 			"version": "2.1.1",
@@ -4562,10 +4831,22 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
+		"component-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+			"dev": true
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
+		},
+		"component-inherit": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
 		},
 		"concat-map": {
@@ -4616,6 +4897,62 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
 			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+			"dev": true
+		},
+		"connect": {
+			"version": "3.6.6",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+			"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.0",
+				"parseurl": "~1.3.2",
+				"utils-merge": "1.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.1",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.3.1",
+						"unpipe": "~1.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+					"dev": true
+				}
+			}
+		},
+		"connect-history-api-fallback": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
 			"dev": true
 		},
 		"console-browserify": {
@@ -5288,6 +5625,12 @@
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
+		"dev-ip": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+			"integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+			"dev": true
+		},
 		"diff-sequences": {
 			"version": "25.2.6",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
@@ -5334,6 +5677,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
+		},
+		"dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"dev": true
 		},
 		"doctrine": {
@@ -5412,6 +5761,12 @@
 				"domelementtype": "1"
 			}
 		},
+		"dotenv": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+			"dev": true
+		},
 		"duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -5454,6 +5809,24 @@
 						"safe-buffer": "~5.1.0"
 					}
 				}
+			}
+		},
+		"easy-extender": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+			"integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.10"
+			}
+		},
+		"eazy-logger": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
+			"integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
+			"dev": true,
+			"requires": {
+				"tfunk": "^4.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -5532,6 +5905,86 @@
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
+			}
+		},
+		"engine.io": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
+			"integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.4.1",
+				"debug": "~4.1.0",
+				"engine.io-parser": "~2.2.0",
+				"ws": "~7.4.2"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+					"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"engine.io-client": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
+			"integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "~1.3.0",
+				"component-inherit": "0.0.3",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.2.0",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.6",
+				"parseuri": "0.0.6",
+				"ws": "~7.4.2",
+				"xmlhttprequest-ssl": "~1.5.4",
+				"yeast": "0.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"engine.io-parser": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+			"integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+			"dev": true,
+			"requires": {
+				"after": "0.8.2",
+				"arraybuffer.slice": "~0.0.7",
+				"base64-arraybuffer": "0.1.4",
+				"blob": "0.0.5",
+				"has-binary2": "~1.0.2"
 			}
 		},
 		"enhanced-resolve": {
@@ -6297,6 +6750,12 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
+		},
+		"eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true
 		},
 		"events": {
@@ -7222,6 +7681,12 @@
 				}
 			}
 		},
+		"follow-redirects": {
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+			"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+			"dev": true
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -7322,6 +7787,17 @@
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
 			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
+		},
+		"fs-extra": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+			"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^3.0.0",
+				"universalify": "^0.1.0"
+			}
 		},
 		"fs-minipass": {
 			"version": "2.1.0",
@@ -7644,6 +8120,46 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
+			}
+		},
+		"has-binary2": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+			"dev": true,
+			"requires": {
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				}
+			}
+		},
+		"has-cors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+			"dev": true
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -7868,6 +8384,17 @@
 			"integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
 			"dev": true
 		},
+		"http-proxy": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7941,6 +8468,12 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
 			"integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
+			"dev": true
+		},
+		"immutable": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
 			"dev": true
 		},
 		"import-cwd": {
@@ -8071,6 +8604,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
 			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+			"dev": true
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
 			"dev": true
 		},
 		"infer-owner": {
@@ -8361,6 +8900,15 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
+		},
+		"is-number-like": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+			"integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+			"dev": true,
+			"requires": {
+				"lodash.isfinite": "^3.3.2"
+			}
 		},
 		"is-number-object": {
 			"version": "1.0.4",
@@ -10221,6 +10769,15 @@
 			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
 			"dev": true
 		},
+		"jsonfile": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -10298,6 +10855,12 @@
 				"type-check": "~0.4.0"
 			}
 		},
+		"limiter": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+			"integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+			"dev": true
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -10359,6 +10922,108 @@
 				}
 			}
 		},
+		"localtunnel": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.1.tgz",
+			"integrity": "sha512-LiaI5wZdz0xFkIQpXbNI62ZnNn8IMsVhwxHmhA+h4vj8R9JG/07bQHWwQlyy7b95/5fVOCHJfIHv+a5XnkvaJA==",
+			"dev": true,
+			"requires": {
+				"axios": "0.21.1",
+				"debug": "4.3.1",
+				"openurl": "1.1.1",
+				"yargs": "16.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.7",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+					"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+					"dev": true
+				}
+			}
+		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -10409,6 +11074,12 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.isfinite": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -11227,6 +11898,12 @@
 				"through2": "^2.0.0"
 			}
 		},
+		"mitt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+			"integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+			"dev": true
+		},
 		"mixin-deep": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -11895,6 +12572,29 @@
 			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
 			"dev": true
 		},
+		"openurl": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
+			"dev": true
+		},
+		"opn": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+			"dev": true,
+			"requires": {
+				"is-wsl": "^1.1.0"
+			},
+			"dependencies": {
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+					"dev": true
+				}
+			}
+		},
 		"optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -12072,6 +12772,18 @@
 				"parse5": "^6.0.1"
 			}
 		},
+		"parseqs": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+			"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+			"dev": true
+		},
+		"parseuri": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+			"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+			"dev": true
+		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -12246,6 +12958,24 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				}
+			}
+		},
+		"portscanner": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+			"integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"is-number-like": "^1.0.3"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				}
 			}
 		},
@@ -12986,12 +13716,6 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
-		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true
-		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -13195,37 +13919,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
-		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@3.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-			"dev": true,
-			"requires": {
-				"@types/mime-types": "^2.1.0",
-				"debug": "^4.1.0",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
-				"mime": "^2.0.3",
-				"mime-types": "^2.1.25",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -13798,6 +14491,12 @@
 			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
 			"dev": true
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -13855,6 +14554,33 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"resp-modifier": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+			"integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.2.0",
+				"minimatch": "^3.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
 		},
 		"ret": {
 			"version": "0.1.15",
@@ -13923,6 +14649,15 @@
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
 			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
 			"dev": true
+		},
+		"rxjs": {
+			"version": "5.5.12",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+			"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "1.0.1"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -14256,6 +14991,62 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.4",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "~1.0.3",
+				"http-errors": "~1.6.2",
+				"mime-types": "~2.1.17",
+				"parseurl": "~1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+					"dev": true
+				}
+			}
+		},
 		"serve-static": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -14267,6 +15058,12 @@
 				"parseurl": "~1.3.3",
 				"send": "0.17.1"
 			}
+		},
+		"server-destroy": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+			"integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -14561,6 +15358,130 @@
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
+				}
+			}
+		},
+		"socket.io": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.0.tgz",
+			"integrity": "sha512-9UPJ1UTvKayuQfVv2IQ3k7tCQC/fboDyIK62i99dAQIyHKaBsNdTpwHLgKJ6guRWxRtC9H+138UwpaGuQO9uWQ==",
+			"dev": true,
+			"requires": {
+				"debug": "~4.1.0",
+				"engine.io": "~3.5.0",
+				"has-binary2": "~1.0.2",
+				"socket.io-adapter": "~1.1.0",
+				"socket.io-client": "2.4.0",
+				"socket.io-parser": "~3.4.0"
+			},
+			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				},
+				"socket.io-parser": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+					"integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
+					"dev": true,
+					"requires": {
+						"component-emitter": "1.2.1",
+						"debug": "~4.1.0",
+						"isarray": "2.0.1"
+					}
+				}
+			}
+		},
+		"socket.io-adapter": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+			"integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
+			"dev": true
+		},
+		"socket.io-client": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
+			"integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+			"dev": true,
+			"requires": {
+				"backo2": "1.0.2",
+				"component-bind": "1.0.0",
+				"component-emitter": "~1.3.0",
+				"debug": "~3.1.0",
+				"engine.io-client": "~3.5.0",
+				"has-binary2": "~1.0.2",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.6",
+				"parseuri": "0.0.6",
+				"socket.io-parser": "~3.3.0",
+				"to-array": "0.1.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+			"integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "~1.3.0",
+				"debug": "~3.1.0",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -14888,6 +15809,16 @@
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
+		},
+		"stream-throttle": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+			"integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+			"dev": true,
+			"requires": {
+				"commander": "^2.2.0",
+				"limiter": "^1.0.5"
+			}
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -15608,6 +16539,12 @@
 				"util.promisify": "~1.0.0"
 			}
 		},
+		"symbol-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+			"dev": true
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15811,6 +16748,58 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
+		"tfunk": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
+			"integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"dlv": "^1.1.3"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
 		"thread-loader": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
@@ -15921,6 +16910,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
 			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-array": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
 			"dev": true
 		},
 		"to-arraybuffer": {
@@ -16132,6 +17127,12 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"ua-parser-js": {
+			"version": "0.7.28",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+			"dev": true
+		},
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -16291,6 +17292,12 @@
 			"requires": {
 				"unist-util-is": "^3.0.0"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -17712,6 +18719,12 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
+		"xmlhttprequest-ssl": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+			"dev": true
+		},
 		"xregexp": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
@@ -17842,6 +18855,12 @@
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
 			}
+		},
+		"yeast": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
 		"@dekode/stylelint-config": "1.0.1",
 		"@teft/postcss-preset": "0.0.1",
 		"@wordpress/scripts": "12.6.1",
+		"browser-sync": "^2.26.14",
+		"browser-sync-webpack-plugin": "^2.3.0",
+		"dotenv": "^8.2.0",
 		"fast-glob": "3.2.5"
 	},
 	"scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,11 +71,11 @@ const config = {
 			moduleFilename: ( { name } ) => getBuildPath( name ).replace( '.js', '.css' ),
 		} ),
 		new FixStyleWebpackPlugin(),
-		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } )
+		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	],
 };
 
-if( browserSyncEnable ) {
+if ( browserSyncEnable ) {
 	config.plugins.push(
 		new BrowserSyncPlugin( {
 			files: '**/*.php',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ const mode = isProduction ? 'production' : 'development';
 const browserSyncProxy = process.env.BROWSER_SYNC_PROXY ? process.env.BROWSER_SYNC_PROXY : process.env.WP_HOME;
 const browserSyncPort = process.env.BROWSER_SYNC_PORT ? process.env.BROWSER_SYNC_PORT : 3002;
 const browserSyncIsHttps = process.env.BROWSER_SYNC_HTTPS === 'true';
+const browserSyncEnable = process.env.BROWSER_SYNC_ENABLE === 'true';
 
 function getBuildPath( name, prefix = '' ) {
 	return `${ name.split( '|' )[ 0 ] }/build/${ prefix }${ name.split( '|' )[ 1 ] }`;
@@ -70,14 +71,19 @@ const config = {
 			moduleFilename: ( { name } ) => getBuildPath( name ).replace( '.js', '.css' ),
 		} ),
 		new FixStyleWebpackPlugin(),
-		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-		new BrowserSyncPlugin( {
+		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } )
+	],
+};
+
+if(browserSyncEnable) {
+	config.plugins.push(
+		new BrowserSyncPlugin({
 			files: '**/*.php',
 			proxy: browserSyncProxy,
 			port: browserSyncPort,
 			https: browserSyncIsHttps,
-		} ),
-	],
-};
+		})
+	);
+}
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,13 @@ const FixStyleWebpackPlugin = require( './node_modules/@wordpress/scripts/config
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 
+const BrowserSyncPlugin = require( 'browser-sync-webpack-plugin' );
+require( 'dotenv' ).config();
+
+const browserSyncProxy = process.env.BROWSER_SYNC_PROXY ? process.env.BROWSER_SYNC_PROXY : process.env.WP_HOME;
+const browserSyncPort = process.env.BROWSER_SYNC_PORT ? process.env.BROWSER_SYNC_PORT : 3002;
+const browserSyncIsHttps = process.env.BROWSER_SYNC_HTTPS === 'true';
+
 function getBuildPath( name, prefix = '' ) {
 	return `${ name.split( '|' )[ 0 ] }/build/${ prefix }${ name.split( '|' )[ 1 ] }`;
 }
@@ -65,6 +72,12 @@ const config = {
 		} ),
 		new FixStyleWebpackPlugin(),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+		new BrowserSyncPlugin( {
+			files: '**/*.php',
+			proxy: browserSyncProxy,
+			port: browserSyncPort,
+			https: browserSyncIsHttps,
+		} ),
 	],
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,14 +75,14 @@ const config = {
 	],
 };
 
-if(browserSyncEnable) {
+if( browserSyncEnable ) {
 	config.plugins.push(
-		new BrowserSyncPlugin({
+		new BrowserSyncPlugin( {
 			files: '**/*.php',
 			proxy: browserSyncProxy,
 			port: browserSyncPort,
 			https: browserSyncIsHttps,
-		})
+		} ),
 	);
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,8 @@ const glob = require( 'fast-glob' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const fs = require( 'fs' );
 const path = require( 'path' );
+const BrowserSyncPlugin = require( 'browser-sync-webpack-plugin' );
+require( 'dotenv' ).config();
 
 /**
  * WordPress dependencies
@@ -15,9 +17,6 @@ const FixStyleWebpackPlugin = require( './node_modules/@wordpress/scripts/config
 
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
-
-const BrowserSyncPlugin = require( 'browser-sync-webpack-plugin' );
-require( 'dotenv' ).config();
 
 const browserSyncProxy = process.env.BROWSER_SYNC_PROXY ? process.env.BROWSER_SYNC_PROXY : process.env.WP_HOME;
 const browserSyncPort = process.env.BROWSER_SYNC_PORT ? process.env.BROWSER_SYNC_PORT : 3002;


### PR DESCRIPTION
Include browser sync webpack plugin in project base to aid development. On npm run start this will open the .local website in a mirrored instance on http://localhost:3002/ (The port can be configured in .env)

Whenever the developer saves a *.js *.css *.php file, this will automatically refresh the proxy instance on localhost. 
Out of the box, there is no need for any configuration and will automatically read the WP_HOME defined in .env

For extra configurations that might be useful see the section at  # Webpack BrowserSync in .env.example by default commented out.

```
# Webpack BrowserSync
#BROWSER_SYNC_ENABLE=true
#BROWSER_SYNC_PROXY=https://sitename.local
#BROWSER_SYNC_PORT=3003
#BROWSER_SYNC_HTTPS=true
```


### Files modified
Add two new devDependencies to package.json:

* BrowserSync
https://browsersync.io/

* Dotenv
Allow reading of  .env file by javascript and use to data in webpack.config.js with user configuration.
This js plugin will also allow us to make some clever customizations in webpack based on env file settings.

In .env
Add browser sync settings to the end of the .env file, if the custom sync proxy url is not specified it will default back to WP_HOME