### PR TITLE
Allow default URLs to be defined via environment files

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -59,20 +59,27 @@ if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
 }
 
 /**
+ * Conditionally use, or generate, `WP_HOME` and `WP_SITEURL`.
+ */
+if ( env( 'WP_HOME' ) ) {
+	define( 'WP_HOME', env( 'WP_HOME' ) );
+	define( 'WP_SITEURL', ( env( 'WP_SITEURL' ) ?: WP_HOME . '/wp' ) );
+} else {
+	$scheme = 'http';
+	if ( ( is_string( $https ) && 'on' === strtolower( $https ) ) || '443' === $server_port || 'https' === $http_x_fp ) {
+		$scheme           = 'https';
+		$_SERVER['HTTPS'] = 'on';
+	}
+
+	define( 'WP_HOME', $scheme . '://' . $http_host );
+	define( 'WP_SITEURL', WP_HOME . '/wp' );
+}
+/**
  * Set the dirs
  */
-$scheme = 'http';
-if ( ( is_string( $https ) && 'on' === strtolower( $https ) ) || '443' === $server_port || 'https' === $http_x_fp ) {
-	$scheme           = 'https';
-	$_SERVER['HTTPS'] = 'on';
-}
-
-define( 'WP_SITEURL', $scheme . '://' . $http_host . '/wp' );
-define( 'WP_HOME', $scheme . '://' . $http_host );
-
 define( 'CONTENT_DIR', '/content' );
 define( 'WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR );
-define( 'WP_CONTENT_URL', $scheme . '://' . $http_host . '/content' );
+define( 'WP_CONTENT_URL', WP_HOME . CONTENT_DIR );
 
 /**
  * DB settings


### PR DESCRIPTION
The `.env.example` file already contains entries for `WP_HOME` and `WP_SITEURL`, but project base never uses these values after the most recent major upgrade to the project base

There are some drawbacks with the current implementation here, specifically in the [definition of `$http_host`](https://github.com/DekodeInteraktiv/project-base/blob/7ef52dcb5277fe8b82a5e06ecaa75d0f8a840bb7/config/application.php#L52), which at this time fetches the value form `$_SERVER['HTTP_HOST']`.

As `HTTP_HOST` uses the host headers from the client, this is unreliable in a hosting-scenario, since it will then change the HOME_URL in WordPress depending on what URL the user visits the site with, if a site has multiple domains pointed at it, this will lead to duplicate content, and no canonical-redirects since WordPress thinks you are on the correct URL at any given time.

Replacing the value with `$_SERVER['SERVER_NAME']` is also not ideal, as this is not a variable available by default in for example Nginx.

The intended purpose here is likely to make a low-setup base, but has some shortcomings as seen above. In light of this, the PR will use a `WP_HOME` and `WP_SITEURL` environment entries if they are defined, and retain the current server-config setup as a fallback, for convenience sake in things like local setups.