### PR TITLE
Introduce Two Factor as a default plugin in project base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
 		"symfony/dotenv": "~5.2.1",
 		"wpackagist-plugin/spinupwp": "~1.2.0",
 		"wpackagist-plugin/imagify": "~1.9.14",
-		"dekode/dekode-theme": "@dev"
+		"dekode/dekode-theme": "@dev",
+		"wpackagist-plugin/two-factor": "~0.7.0"
 	},
 	"require-dev": {
 		"dekode/coding-standards": "4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2ef2d87862e7bfb0e3e052d325eb86c",
+    "content-hash": "b941066d649855809c33319fb81b5f40",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -606,6 +606,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/spinupwp/"
+        },
+        {
+            "name": "wpackagist-plugin/two-factor",
+            "version": "0.7.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/two-factor/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/two-factor.zip?timestamp=1598435994"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/two-factor/"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
As more and more users become security-oriented, we should not leave possible enhancements here as an afterthought.

This implements the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as a default available plugin in project base for all future project setups. Given that this is a WordPress feature plugin, it is also the intention for it to (hopefully) be implemented in WordPress core at some point in the future.

By using this as a default (and allowing for other implementations on a per-project basis if there's very specific needs), this future-proofs projects, as any such plugin would then also be planned for graceful decoupling in a future where this is built into WordPress it self.