### PR TITLE
Add setting to disable Redis.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ WP_SITEURL=${WP_HOME}/wp
 
 ### Cache
 WP_REDIS_HOST=false
+WP_REDIS_DISABLED=true
 
 ### Disable WP Cron
 DISABLE_WP_CRON=false

--- a/config/application.php
+++ b/config/application.php
@@ -88,6 +88,13 @@ define( 'DB_COLLATE', '' );
 $table_prefix = env( 'DB_PREFIX' ) ?: 'wp_';
 
 /**
+ * Disable Redis if the environment file decrees it so.
+ */
+if ( env( 'WP_REDIS_DISABLED' ) && 'true' === env( 'WP_REDIS_DISABLED' ) ) {
+	define( 'WP_REDIS_DISABLED', true );
+}
+
+/**
  * Authentication Unique Keys and Salts
  */
 define( 'AUTH_KEY', env( 'AUTH_KEY' ) );


### PR DESCRIPTION
This introduces the concept of `WP_REDIS_DISABLED` to the `.env.example` file, and if it is defined, will disable Redis entirely.

The default value in the environment file is set to `true`, to disable it, while not having this defined at all will default to enabling it. This ensures we don't accidentally disable it if any sites wish to update Project Base at any point.

See #195