### PR TITLE
Lint main branch

### DIFF
--- a/.github/workflows/lint-js-css.yml
+++ b/.github/workflows/lint-js-css.yml
@@ -2,9 +2,9 @@ name: Lint JS and CSS
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -2,9 +2,9 @@ name: PHP CodeSniffer
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   phpcs:


### PR DESCRIPTION
Change linting to lint `main` branch after renaming `master` to `main`.