### PR TITLE
MU Plugin: Site Health quality assurance.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
 		"symfony/dotenv": "~5.2.1",
 		"wpackagist-plugin/imagify": "~1.9.14",
 		"wpackagist-plugin/spinupwp": "~1.3.0",
-		"wpackagist-plugin/two-factor": "~0.7.0"
+		"wpackagist-plugin/two-factor": "~0.7.0",
+		"dekode/site-health": "@dev"
 	},
 	"require-dev": {
 		"dekode/coding-standards": "4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17903a0857afb6606f9fbccc38df3bf1",
+    "content-hash": "c988e22493817c897ce1ea683fa52631",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -228,6 +228,30 @@
                 "GPL-3.0-or-later"
             ],
             "description": "Dekode boiler plate theme",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "dekode/site-health",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/mu-plugins/site-health",
+                "reference": "a38fcb10091210926a6971c68196072ad70be5bf"
+            },
+            "type": "wordpress-muplugin",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Dekode Interaktiv",
+                    "homepage": "https://dekode.no"
+                }
+            ],
+            "description": "Utility plugin to ensure Site Health reports match expectations of Project Base.",
             "transport-options": {
                 "symlink": true,
                 "relative": true
@@ -1718,6 +1742,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "dekode/dekode-theme": 20,
+        "dekode/site-health": 20,
         "dekode/logging": 20
     },
     "prefer-stable": true,

--- a/config/application.php
+++ b/config/application.php
@@ -43,6 +43,14 @@ $dotenv->load( $root_dir . '/.env' );
  */
 define( 'WP_ENV', env( 'WP_ENV' ) ?: 'production' );
 
+/**
+ * Mirror the Bedrock-style environment type in WordPress' constant as well.
+ *
+ * By doing so, we ensure that plugins and themes relying on the environment data
+ * provided by WordPress core behave as expected depending on the applicable sitaution.
+ */
+define( 'WP_ENVIRONMENT_TYPE', WP_ENV );
+
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 
 if ( file_exists( $env_config ) ) {

--- a/packages/mu-plugins/site-health/composer.json
+++ b/packages/mu-plugins/site-health/composer.json
@@ -1,0 +1,13 @@
+{
+	"name": "dekode/site-health",
+	"description": "Utility plugin to ensure Site Health reports match expectations of Project Base.",
+	"version": "1.0.0",
+	"type": "wordpress-muplugin",
+	"license": "GPL-3.0-or-later",
+	"authors": [
+		{
+			"name": "Dekode Interaktiv",
+			"homepage": "https://dekode.no"
+		}
+	]
+}

--- a/packages/mu-plugins/site-health/includes/class-site-health.php
+++ b/packages/mu-plugins/site-health/includes/class-site-health.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Class file for the SiteHealth plugin module.
+ *
+ * @package Dekode\MUPlugin\SiteHealth
+ */
+
+declare( strict_types=1 );
+
+namespace Dekode\MUPlugin\SiteHealth;
+
+/**
+ * Class SiteHealth
+ *
+ * @package Dekode\MUPlugin\SiteHealth
+ */
+class Site_Health {
+
+	/**
+	 * SiteHealth constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		add_filter( 'site_status_tests', [ $this, 'remove_undesired_tests' ] );
+		add_filter( 'site_status_test_result', [ $this, 'filter_debug_log_results' ] );
+	}
+
+	/**
+	 * Checks if the current environment type is set to 'development' or 'local'.
+	 *
+	 * Copied from `WP_Site_Health::is_development_environment` to ensure availability in this plugin.
+	 *
+	 * @return bool True if it is a development environment, false if not.
+	 */
+	public function is_development_environment() : bool {
+		return in_array( wp_get_environment_type(), [ 'development', 'local' ], true );
+	}
+
+	/**
+	 * Filter the debug log result.
+	 *
+	 * If this is a development environment, give a more direct explanation of what the
+	 * status of logging is on this site.
+	 *
+	 * @param array $result A Site Health test result.
+	 *
+	 * @return array
+	 */
+	public function filter_debug_log_results( array $result ) : array {
+		// If this is a development environment, debug mode is expected to be on, so return the default output.
+		if ( 'is_in_debug_mode' === $result['test'] && $this->is_development_environment() ) {
+			$result = [
+				'label'       => __( 'This site is providing debug information' ),
+				'status'      => 'good',
+				'badge'       => [
+					'label' => __( 'Security' ),
+					'color' => 'blue',
+				],
+				'description' => sprintf(
+					'<p>%s</p>',
+					__( 'This website is currently running in a development environment, and is expected to be able to output information relating to errors, warnings, and other information plugins or themes may expose in such a situation.' )
+				),
+				'actions'     => sprintf(
+					'<p><a href="%s" target="_blank" rel="noopener noreferrer">%s <span class="screen-reader-text">%s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
+					/* translators: Documentation explaining debugging in WordPress. */
+					esc_url( __( 'https://wordpress.org/support/article/debugging-in-wordpress/' ) ),
+					__( 'Read about debugging in WordPress.' ),
+					/* translators: accessibility text */
+					__( '(opens in a new tab)' )
+				),
+				'test'        => 'is_in_debug_mode',
+			];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Filter the available tests on this site.
+	 *
+	 * Removes tests that are prone to give an incorrect result when considering
+	 * the deployment and package environment used.
+	 *
+	 * @param array $tests An array of available tests.
+	 *
+	 * @return array
+	 */
+	public function remove_undesired_tests( array $tests ) : array {
+		/*
+		 * Since the project is managed via Composer, no default themes are installed, and theme versions are
+		 * project specific, so would be unlikely to have matches on WordPress.org to compare against.
+		 */
+		unset( $tests['direct']['theme_version'] );
+
+		/*
+		 * Plugins are installed via Composer, it is not possible to update, install, or remove them via the
+		 * WordPress back-end, and should they become inactive this is intentional, and they will instead be
+		 * removed using Composer if they are no longer required.
+		 */
+		unset( $tests['direct']['plugin_version'] );
+
+		/*
+		 * Projects managed by Composer are usually maintained via version control, as such
+		 * automated updates of any kind will be disabled.
+		 */
+		unset( $tests['direct']['plugin_theme_auto_updates'] );
+		unset( $tests['async']['background_updates'] );
+
+		return $tests;
+	}
+
+}

--- a/packages/mu-plugins/site-health/includes/class-site-health.php
+++ b/packages/mu-plugins/site-health/includes/class-site-health.php
@@ -51,23 +51,23 @@ class Site_Health {
 		// If this is a development environment, debug mode is expected to be on, so return the default output.
 		if ( 'is_in_debug_mode' === $result['test'] && $this->is_development_environment() ) {
 			$result = [
-				'label'       => __( 'This site is providing debug information' ),
+				'label'       => __( 'This site is providing debug information', 'dekode-muplugin-site-health' ),
 				'status'      => 'good',
 				'badge'       => [
-					'label' => __( 'Security' ),
+					'label' => __( 'Security', 'dekode-muplugin-site-health' ),
 					'color' => 'blue',
 				],
 				'description' => sprintf(
 					'<p>%s</p>',
-					__( 'This website is currently running in a development environment, and is expected to be able to output information relating to errors, warnings, and other information plugins or themes may expose in such a situation.' )
+					__( 'This website is currently running in a development environment, and is expected to be able to output information relating to errors, warnings, and other information plugins or themes may expose in such a situation.', 'dekode-muplugin-site-health' )
 				),
 				'actions'     => sprintf(
 					'<p><a href="%s" target="_blank" rel="noopener noreferrer">%s <span class="screen-reader-text">%s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
 					/* translators: Documentation explaining debugging in WordPress. */
-					esc_url( __( 'https://wordpress.org/support/article/debugging-in-wordpress/' ) ),
-					__( 'Read about debugging in WordPress.' ),
+					esc_url( __( 'https://wordpress.org/support/article/debugging-in-wordpress/', 'dekode-muplugin-site-health' ) ),
+					__( 'Read about debugging in WordPress.', 'dekode-muplugin-site-health' ),
 					/* translators: accessibility text */
-					__( '(opens in a new tab)' )
+					__( '(opens in a new tab)', 'dekode-muplugin-site-health' )
 				),
 				'test'        => 'is_in_debug_mode',
 			];

--- a/packages/mu-plugins/site-health/readme.md
+++ b/packages/mu-plugins/site-health/readme.md
@@ -1,0 +1,5 @@
+# Site Health Quality Assurance
+
+The Site Health feature in WordPress is great for indicating problems with a site, but depending on your setup, can also provide some false-positive results that are unexpected or unwanted.
+
+This introduces the concept of a MU plugin that tackles this by removing tests with known false-positives relating to updates, plugins and themes, which are all managed via version control and Composer, and more.

--- a/packages/mu-plugins/site-health/site-health.php
+++ b/packages/mu-plugins/site-health/site-health.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name:  Site Health Quality Assurance
+ * Description:  Utility plugin to ensure Site Health reports match expectations of Project Base.
+ * Version:      1.0.0
+ * Author:       Dekode Interaktiv
+ *
+ * @package Dekode/MU
+ */
+
+declare( strict_types=1 );
+
+namespace Dekode\MUPlugin\SiteHealth;
+
+require_once __DIR__ . '/includes/class-site-health.php';
+
+new Site_Health();

--- a/packages/mu-plugins/site-health/site-health.php
+++ b/packages/mu-plugins/site-health/site-health.php
@@ -4,6 +4,7 @@
  * Description:  Utility plugin to ensure Site Health reports match expectations of Project Base.
  * Version:      1.0.0
  * Author:       Dekode Interaktiv
+ * Text Domain:  dekode-muplugin-site-health
  *
  * @package Dekode/MU
  */


### PR DESCRIPTION
The Site Health feature in WordPress is great for indicating problems with a site, but depending on your setup, can also provide some false-positive results that are unexpected or unwanted.

This introduces the concept of a MU plugin that tackles this by removing tests with known false-positives relating to updates, plugins and themes, which are all managed via version control and Composer.

It also implements the `WP_ENVIRONMENT_TYPE` constant, that mirrors the existing `WP_ENV` constant. This ensures that plugins or themes that rely on WordPress' native environment types will get an expected result.

This is being introduced as a package in project base, and not a standalone plugin, because it's a very specific need and set of rules, relative to the use of Bedrock-based setups and deployments.