### PR TITLE
Add custom logpath to `WP_DEBUG_LOG`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ sql/
 
 # Other
 debug.log
+wp-debug.log

--- a/config/application.php
+++ b/config/application.php
@@ -81,9 +81,19 @@ define( 'CONTENT_DIR', '/content' );
 define( 'WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR );
 define( 'WP_CONTENT_URL', WP_HOME . CONTENT_DIR );
 
-if ( ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
+if ( ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Code runs before WordPress is initialized.
 	// If the document root can be determined, use it as the base for the logfile location.
-	define( 'WP_DEBUG_LOG', rtrim( dirname( $_SERVER['DOCUMENT_ROOT'] ), '/' ) . '/logs/wp-debug.log' );
+	$document_root = filter_input( INPUT_SERVER, 'DOCUMENT_ROOT', FILTER_SANITIZE_STRING );
+
+	/*
+	 * Validate that the document root path has no path traversal strings as part of it,
+	 * if not fallback to default logging locations.
+	 */
+	if ( empty( $document_root ) || stristr( $document_root, '..' ) ) {
+		define( 'WP_DEBUG_LOG', true );
+	} else {
+		define( 'WP_DEBUG_LOG', rtrim( dirname( $document_root ), '/' ) . '/logs/wp-debug.log' );
+	}
 } else {
 	// Fallback to enable debug logging to WordPress' default location.
 	define( 'WP_DEBUG_LOG', true );

--- a/config/application.php
+++ b/config/application.php
@@ -81,6 +81,14 @@ define( 'CONTENT_DIR', '/content' );
 define( 'WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR );
 define( 'WP_CONTENT_URL', WP_HOME . CONTENT_DIR );
 
+if ( ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
+	// If the document root can be determined, use it as the base for the logfile location.
+	define( 'WP_DEBUG_LOG', rtrim( dirname( $_SERVER['DOCUMENT_ROOT'] ), '/' ) . '/logs/wp-debug.log' );
+} else {
+	// Fallback to enable debug logging to WordPress' default location.
+	define( 'WP_DEBUG_LOG', true );
+}
+
 /**
  * DB settings
  */

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -9,7 +9,6 @@ declare( strict_types = 1 );
 
 define( 'SAVEQUERIES', true );
 define( 'WP_DEBUG', true );
-define( 'WP_DEBUG_LOG', true );
 define( 'SCRIPT_DEBUG', true );
 define( 'WP_DEBUG_DISPLAY', true );
 


### PR DESCRIPTION
Although logging is only enabled if a development environment is enabled, these sites may also be publicly exposed on the internet.

Creating a log directory in the root of Project Base puts these logs outside the publicly available area of a website, removing the risk of potentially sharing sensitive information.

It also moves the registration of `WP_DEBUG_LOG` out of the environment specific files, and sets it on the application level in `application.php` for all environments. Setting this constant has no impact on if debug logging is enabled or not, and ensures that if someone accidentally enables debugging outside of development environments, it will always lead to logs ending up in our dedicated directory.