### PR TITLE
Use `WP_ENVIROMENT_TYPE` instead of `WP_ENV`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # the environment. You will need to restart your environment when changing any of these.
 ##
 
-# Environment. Valid options are development, stage or production
-WP_ENV=development
+# Environment. Valid options are local, development, staging or production
+WP_ENVIRONMENT_TYPE=local
 #WP_CLI_HOME=local.site # optional
 
 ### API Database

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -35,7 +35,7 @@ Themes, plugins, mu-plugins etc. is now structured under packages and built into
   * `DB_USER` - Database user
   * `DB_PASSWORD` - Database password
   * `DB_HOST` - Database host
-  * `WP_ENV` - Set to environment (`development`, `staging`, `production`)
+  * `WP_ENVIRONMENT_TYPE` - Set to environment (`local`, `development`, `staging`, `production`)
   * `WP_HOME` - Full URL to WordPress home (http://example.com)
   * `WP_SITEURL` - Full URL to WordPress including subdirectory (http://example.com/wp)
   * `AUTH_KEY`, `SECURE_AUTH_KEY`, `LOGGED_IN_KEY`, `NONCE_KEY`, `AUTH_SALT`, `SECURE_AUTH_SALT`, `LOGGED_IN_SALT`, `NONCE_SALT`

--- a/config/application.php
+++ b/config/application.php
@@ -38,20 +38,19 @@ $dotenv = new \Symfony\Component\Dotenv\Dotenv();
 $dotenv->load( $root_dir . '/.env' );
 
 /**
- * Set up our global environment constant and load its config first
- * Default: production
- */
-define( 'WP_ENV', env( 'WP_ENV' ) ?: 'production' );
-
-/**
- * Mirror the Bedrock-style environment type in WordPress' constant as well.
+ * Set up our global environment constant
  *
  * By doing so, we ensure that plugins and themes relying on the environment data
  * provided by WordPress core behave as expected depending on the applicable sitaution.
+ *
+ * Default: production
  */
-define( 'WP_ENVIRONMENT_TYPE', WP_ENV );
+define( 'WP_ENVIRONMENT_TYPE', env( 'WP_ENVIRONMENT_TYPE' ) ?: 'production' );
 
-$env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
+/**
+ * Load enviroment config
+ */
+$env_config = __DIR__ . '/environments/' . WP_ENVIRONMENT_TYPE . '.php';
 
 if ( file_exists( $env_config ) ) {
 	require_once $env_config;

--- a/config/environments/local.php
+++ b/config/environments/local.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Application local config.
+ *
+ * @package Dekode
+ */
+
+declare( strict_types = 1 );
+
+define( 'SAVEQUERIES', true );
+define( 'WP_DEBUG', true );
+define( 'SCRIPT_DEBUG', true );
+define( 'WP_DEBUG_DISPLAY', true );
+
+if ( defined( 'WP_CLI' ) && WP_CLI && env( 'MYSQLI_DEFAULT_SOCKET' ) ) {
+	ini_set( 'mysqli.default_socket', env( 'MYSQLI_DEFAULT_SOCKET' ) ); // phpcs:ignore
+}


### PR DESCRIPTION
Remove `WP_ENV` in favor of `WP_ENVIROMENT_TYPE`.

Can't see a reason for having both and WP uses `WP_ENVIROMENT_TYPE` in the `wp_get_environment_type` function.

Also added a local config because `local` is a valid type