### PR TITLE
Capture failures in sub-processes and propagate the results accordingly.

### DIFF
--- a/tools/codeship/pre-deploy.sh
+++ b/tools/codeship/pre-deploy.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 cd ~/clone
+
 composer build-for-deploy
+if [[ $? -ne 0 ]] ; then
+	echo "Composer build failure"
+	exit 1
+fi
+
 npm run build
+if [[ $? -ne 0 ]] ; then
+	echo "NPM build failure"
+	exit 1
+fi
 
 files=(
 	.git

--- a/tools/codeship/test-lint.sh
+++ b/tools/codeship/test-lint.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 
 cd ~/clone
-npm run lint && composer lint
+
+npm run lint
+NPMSTATUS=$?
+
+composer lint
+COMPOSERSTATUS=$?
+
+## If either linter has a failure, throw a non-zero exit code for the whole lint procedure.
+## Doing it this way ensures both linters can run, so you get a full status without needing multiple code pushes.
+if [[ $NPMSTATUS -ne 0 || $COMPOSERSTATUS -ne 0 ]] ; then
+	exit 1
+fi


### PR DESCRIPTION
The current build tools run build steps as sub-processes of a bash script. This means if an error happens, the error state is passed to the script runner for processing.

Since there was no error handling, the next step would be completed, and when the file reached its end, the status of the last command bubbles up to the Codeship runner. This causes issues, as the final command just sees if it can find any folders named `node_modules` and removes them, this is unlikely to ever fail, and isn't truly a part of the build process, but rather the cleanup after.

This PR introduces a check after the Composer, and NPM, build steps. Capturing any issue, and immediately terminating and exposing a non-zero exit code which should prevent any deploy from completing.

It also adds in a check at the end of the linter. In this case both linters are intentionally allowed to run even if one of them fails, and the end result is what we matters. This means that any lint operation should be allowed to complete before a failure state is recognized, avoiding multiple pushes to get the full feedback.