### PR TITLE
Throw error in eslint when using unsafe wp apis

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	],
 	plugins: [
 		'@dekode',
+		'@wordpress',
 	],
 	settings: {
 		react: {
@@ -12,6 +13,7 @@ module.exports = {
 		},
 	},
 	rules: {
+		'@wordpress/no-unsafe-wp-apis': 'error',
 		'react/react-in-jsx-scope': 'off',
 		'react/jsx-pascal-case': 'off',
 		'react/jsx-props-no-spreading': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,6 +2336,12 @@
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
 		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"dev": true
+		},
 		"@types/mdast": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.9.tgz",
@@ -2527,13 +2533,13 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz",
-			"integrity": "sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
+			"integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.29.2",
-				"@typescript-eslint/scope-manager": "4.29.2",
+				"@typescript-eslint/experimental-utils": "4.30.0",
+				"@typescript-eslint/scope-manager": "4.30.0",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -2553,55 +2559,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz",
-			"integrity": "sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+			"integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.2",
-				"@typescript-eslint/types": "4.29.2",
-				"@typescript-eslint/typescript-estree": "4.29.2",
+				"@typescript-eslint/scope-manager": "4.30.0",
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/typescript-estree": "4.30.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.2.tgz",
-			"integrity": "sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
+			"integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.29.2",
-				"@typescript-eslint/types": "4.29.2",
-				"@typescript-eslint/typescript-estree": "4.29.2",
+				"@typescript-eslint/scope-manager": "4.30.0",
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/typescript-estree": "4.30.0",
 				"debug": "^4.3.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
-			"integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+			"integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.2",
-				"@typescript-eslint/visitor-keys": "4.29.2"
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/visitor-keys": "4.30.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.2.tgz",
-			"integrity": "sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+			"integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz",
-			"integrity": "sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+			"integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.2",
-				"@typescript-eslint/visitor-keys": "4.29.2",
+				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/visitor-keys": "4.30.0",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -2621,12 +2627,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.29.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz",
-			"integrity": "sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==",
+			"version": "4.30.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+			"integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/types": "4.30.0",
 				"eslint-visitor-keys": "^2.0.0"
 			},
 			"dependencies": {
@@ -2939,9 +2945,9 @@
 			},
 			"dependencies": {
 				"axe-core": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.2.tgz",
-					"integrity": "sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
+					"integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
 					"dev": true
 				},
 				"debug": {
@@ -2963,9 +2969,9 @@
 					}
 				},
 				"eslint-plugin-import": {
-					"version": "2.24.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.1.tgz",
-					"integrity": "sha512-KSFWhNxPH8OGJwpRJJs+Z7I0a13E2iFQZJIvSnCu6KUs4qmgAm3xN9GYBCSoiGWmwA7gERZPXqYQjcoCROnYhQ==",
+					"version": "2.24.2",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+					"integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
 					"dev": true,
 					"requires": {
 						"array-includes": "^3.1.3",
@@ -2982,7 +2988,7 @@
 						"pkg-up": "^2.0.0",
 						"read-pkg-up": "^3.0.0",
 						"resolve": "^1.20.0",
-						"tsconfig-paths": "^3.10.1"
+						"tsconfig-paths": "^3.11.0"
 					}
 				},
 				"eslint-plugin-jsx-a11y": {
@@ -3005,14 +3011,15 @@
 					}
 				},
 				"eslint-plugin-react": {
-					"version": "7.24.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
-					"integrity": "sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==",
+					"version": "7.25.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
+					"integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
 					"dev": true,
 					"requires": {
 						"array-includes": "^3.1.3",
 						"array.prototype.flatmap": "^1.2.4",
 						"doctrine": "^2.1.0",
+						"estraverse": "^5.2.0",
 						"has": "^1.0.3",
 						"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 						"minimatch": "^3.0.4",
@@ -3042,6 +3049,12 @@
 					"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
 					"dev": true
 				},
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -3049,6 +3062,15 @@
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.8.1"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
 					}
 				},
 				"jsx-ast-utils": {
@@ -3104,12 +3126,6 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-					"dev": true
-				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -3129,6 +3145,18 @@
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.11.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+					"integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+					"dev": true,
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"devDependencies": {
 		"@dekode/eslint-plugin": "0.0.1",
 		"@dekode/stylelint-config": "1.0.1",
+		"@wordpress/eslint-plugin": "9.1.1",
 		"@wordpress/scripts": "18.0.0",
 		"autoprefixer": "10.3.3",
 		"browser-sync": "^2.27.5",


### PR DESCRIPTION
Throws error in eslint when using `__experimental` and `__unstable` imports from WordPress

See https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/no-unsafe-wp-apis.md