### PR TITLE
Update documentation and default config file with new anonymizer repository details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ List all non-standard cronjobs on the site and say a few words about the purpose
 ## Anonymization
 Project data is anonymized using a config file, `anonymize.config.json`, where the developer is expected to declare any Personally Identifiable Information (PII) for the project in a data structure relating to database tables and entries.
 
-This anonymization is performed using the [anonymize-mysqldump project](https://github.com/humanmade/go-anonymize-mysqldump), where you can also see the [structure of the config file](https://github.com/humanmade/go-anonymize-mysqldump#config-file).
+This anonymization is performed using the [anonymize-mysqldump project](https://github.com/DekodeInteraktiv/go-anonymize-mysqldump), where you can also see the [structure of the config file](https://github.com/DekodeInteraktiv/go-anonymize-mysqldump#config-file).
 
 The default configuration file provides support for a vanilla WordPress installation, with just data relating to comments and usermeta accounted for.

--- a/anonymize.config.json
+++ b/anonymize.config.json
@@ -96,6 +96,7 @@
 		},
 		{
 			"tableName": "wp_comments",
+			"tableNameRegex": ".*_comments",
 			"fields": [
 				{
 					"field": "comment_author",


### PR DESCRIPTION
This PR updates the readme references to from the Human Made anonymizer tool, to our forked version of it. We chose this direction as the original project has gone unmaintained for a few years now, with no indication of being revived.

It also updates the default anonymizer config file (`anonymize.config.json`) to be multisite-compliant out of the box by supporting the new features found in version 0.4.0 of the anonymizer tool (available through our branch).