### PR TITLE
Optimize makepot composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,8 @@
 		"build-for-deploy": [
 			"@composer install --no-dev && composer wp-translation-downloader:download"
 		],
-		"makepot": [
-			"./vendor/bin/wp i18n make-pot . --exclude=\".github,plugins,public/content/plugins,vendor,public/wp,node_modules,tests\" --slug=project-base"
+		"make-pot": [
+			"./vendor/bin/wp i18n make-pot . languages/project-base.pot --exclude=\".github,plugins,public/content/plugins,vendor,public/wp,node_modules,tests\" --slug=project-base"
 		]
 	}
 }


### PR DESCRIPTION
Rename makepot script to follow the same naming as the actual subscript and set destination path for the generated pot-file