### PR TITLE
Format files with wp-scripts format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,9 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
-[{.jshintrc,*.yml}]
+[{.jshintrc,*.yml,*.yaml}]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [{*.txt,wp-config-sample.php}]
 end_of_line = crlf

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,4 @@
-public/content/languages
-public/content/plugins
-public/content/themes
-public/content/uploads
-
+public
 node_modules
 dist
 build

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,12 @@
 module.exports = {
-	extends: [ 'plugin:@dekode/base', 'plugin:@dekode/react' ],
-	plugins: [ '@dekode', '@wordpress' ],
-	settings: {
-		react: {
-			version: '16.9.0',
-		},
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	globals: {
+		wp: 'off',
 	},
 	rules: {
+		'jsdoc/require-param': 'off',
+		'@wordpress/no-global-event-listener': 'off',
+		'@wordpress/dependency-group': 'error',
 		'@wordpress/no-unsafe-wp-apis': 'error',
-		'react/react-in-jsx-scope': 'off',
-		'react/jsx-pascal-case': 'off',
-		'react/jsx-props-no-spreading': 'off',
-		'no-undefined': 'off',
-		'import/no-unresolved': [
-			'error',
-			{
-				ignore: [ '@wordpress' ],
-			},
-		],
-		'jsx-a11y/media-has-caption': 'off',
 	},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,6 @@
 module.exports = {
-	extends: [
-		'plugin:@dekode/base',
-		'plugin:@dekode/react',
-	],
-	plugins: [
-		'@dekode',
-		'@wordpress',
-	],
+	extends: [ 'plugin:@dekode/base', 'plugin:@dekode/react' ],
+	plugins: [ '@dekode', '@wordpress' ],
 	settings: {
 		react: {
 			version: '16.9.0',
@@ -18,9 +12,12 @@ module.exports = {
 		'react/jsx-pascal-case': 'off',
 		'react/jsx-props-no-spreading': 'off',
 		'no-undefined': 'off',
-		'import/no-unresolved': [ 'error', {
-			ignore: [ '@wordpress' ],
-		} ],
+		'import/no-unresolved': [
+			'error',
+			{
+				ignore: [ '@wordpress' ],
+			},
+		],
 		'jsx-a11y/media-has-caption': 'off',
 	},
 };

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,32 @@
 version: 2
 registries:
-  composer-packages-dekodes-no:
-    type: composer-repository
-    url: https://packages.dekodes.no
-    username: ${{secrets.COMPOSER_REPOSITORY_PACKAGES_DEKODES_NO_USERNAME}}
-    password: ${{secrets.COMPOSER_REPOSITORY_PACKAGES_DEKODES_NO_PASSWORD}}
+    composer-packages-dekodes-no:
+        type: composer-repository
+        url: https://packages.dekodes.no
+        username: ${{secrets.COMPOSER_REPOSITORY_PACKAGES_DEKODES_NO_USERNAME}}
+        password: ${{secrets.COMPOSER_REPOSITORY_PACKAGES_DEKODES_NO_PASSWORD}}
 updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: weekly
-      timezone: Europe/Oslo
-      time: "09:00"
-    open-pull-requests-limit: 30
-    rebase-strategy: disabled
-  - package-ecosystem: composer
-    directory: "/"
-    schedule:
-      interval: weekly
-      timezone: Europe/Oslo
-      time: "09:00"
-    open-pull-requests-limit: 30
-    rebase-strategy: disabled
-    registries:
-      - composer-packages-dekodes-no
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-      timezone: Europe/Oslo
-      time: "09:00"
+    - package-ecosystem: npm
+      directory: '/'
+      schedule:
+          interval: weekly
+          timezone: Europe/Oslo
+          time: '09:00'
+      open-pull-requests-limit: 30
+      rebase-strategy: disabled
+    - package-ecosystem: composer
+      directory: '/'
+      schedule:
+          interval: weekly
+          timezone: Europe/Oslo
+          time: '09:00'
+      open-pull-requests-limit: 30
+      rebase-strategy: disabled
+      registries:
+          - composer-packages-dekodes-no
+    - package-ecosystem: github-actions
+      directory: '/'
+      schedule:
+          interval: weekly
+          timezone: Europe/Oslo
+          time: '09:00'

--- a/.github/workflows/lint-js-css.yml
+++ b/.github/workflows/lint-js-css.yml
@@ -1,40 +1,40 @@
 name: Lint JS and CSS
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-    paths:
-      - '**.css'
-      - '**.js'
-      - '**.json'
-      - '**.yml'
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+        paths:
+            - '**.css'
+            - '**.js'
+            - '**.json'
+            - '**.yml'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
 
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: npm
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14.x
+                  cache: npm
 
-      - name: Install Dependencies
-        run: npm ci
+            - name: Install Dependencies
+              run: npm ci
 
-      - name: Lint CSS
-        run: npm run lint:css
+            - name: Lint CSS
+              run: npm run lint:css
 
-      - name: Lint JS
-        run: npm run lint:js
+            - name: Lint JS
+              run: npm run lint:js

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,66 +1,66 @@
 name: PHP CodeSniffer
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '**.php'
-      - 'composer.lock'
-      - '**.json'
-      - '**.yml'
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+        paths:
+            - '**.php'
+            - 'composer.lock'
+            - '**.json'
+            - '**.yml'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
 
 jobs:
-  phpcs:
-    name: PHP coding standards
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+    phpcs:
+        name: PHP coding standards
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+            - name: Get Composer cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+            - name: Set up Composer caching
+              uses: actions/cache@v2
+              env:
+                  cache-name: cache-composer-dependencies
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-          tools: composer, cs2pr
+            - name: Set up PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  coverage: none
+                  tools: composer, cs2pr
 
-      - name: Log debug information
-        run: |
-          php --version
-          composer --version
+            - name: Log debug information
+              run: |
+                  php --version
+                  composer --version
 
-      - name: Install Composer dependencies
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "vendor/bin" >> $GITHUB_PATH
+            - name: Install Composer dependencies
+              env:
+                  COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+              run: |
+                  composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+                  echo "vendor/bin" >> $GITHUB_PATH
 
-      - name: Log PHPCS debug information
-        run: vendor/bin/phpcs -i
+            - name: Log PHPCS debug information
+              run: vendor/bin/phpcs -i
 
-      - name: Run PHPCS on all files
-        run: vendor/bin/phpcs . -q -n --report=checkstyle | cs2pr
+            - name: Run PHPCS on all files
+              run: vendor/bin/phpcs . -q -n --report=checkstyle | cs2pr

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,4 @@
-public/content/languages
-public/content/plugins
-public/content/uploads
-
+public
 node_modules
 dist
 build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+public/content/languages
+public/content/plugins
+public/content/uploads
+
+node_modules
+dist
+build
+vendor
+wp
+*.css

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require( '@wordpress/prettier-config' );

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,8 +1,4 @@
-public/content/languages
-public/content/plugins
-public/content/themes
-public/content/uploads
-
+public
 node_modules
 dist
 build

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,20 +19,20 @@
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-			"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+			"version": "7.15.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+			"integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.15.0",
-				"@babel/helper-compilation-targets": "^7.15.0",
-				"@babel/helper-module-transforms": "^7.15.0",
-				"@babel/helpers": "^7.14.8",
-				"@babel/parser": "^7.15.0",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-compilation-targets": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.4",
+				"@babel/helpers": "^7.15.4",
+				"@babel/parser": "^7.15.5",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -41,48 +41,71 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-			"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+			"integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.15.0",
+				"@babel/types": "^7.15.4",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
-			"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
-			"integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
+			"integrity": "sha512-P8o7JP2Mzi0SdC6eWr1zF+AEYvrsZa7GSY1lTayjF5XJhVH0kjLYUZPvTMflP7tBgZoe9gIhTa60QwFpqh/E0Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-explode-assignable-expression": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-			"integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+			"integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
 			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.15.0",
@@ -100,17 +123,17 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
-			"integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+			"integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-member-expression-to-functions": "^7.15.0",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.15.0",
-				"@babel/helper-split-export-declaration": "^7.14.5"
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
@@ -148,84 +171,84 @@
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
-			"integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.15.4.tgz",
+			"integrity": "sha512-J14f/vq8+hdC2KoWLIQSsGrC9EFBKE4NFts8pfMpymfApds+fPqR30AOUWc4tyr56h9l/GA1Sxv2q3dLZWbQ/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-			"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+			"integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-get-function-arity": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-			"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+			"integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-			"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+			"integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-			"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+			"integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.15.0"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-			"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-			"integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+			"integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.15.0",
-				"@babel/helper-simple-access": "^7.14.8",
-				"@babel/helper-split-export-declaration": "^7.14.5",
+				"@babel/helper-module-imports": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-simple-access": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
 				"@babel/helper-validator-identifier": "^7.14.9",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-			"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+			"integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -235,53 +258,53 @@
 			"dev": true
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
-			"integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.15.4.tgz",
+			"integrity": "sha512-v53MxgvMK/HCwckJ1bZrq6dNKlmwlyRNYM6ypaRTdXWGOE2c1/SCa6dL/HimhPulGhZKw9W0QhREM583F/t0vQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-wrap-function": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-wrap-function": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-			"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+			"integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.15.0",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-			"integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+			"integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.8"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
-			"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+			"integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-			"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+			"integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -297,26 +320,26 @@
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
-			"integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz",
+			"integrity": "sha512-Y2o+H/hRV5W8QhIfTpRIBwl57y8PrZt6JM3V8FOo5qarjshHItyH5lXlpMfBfmBefOqSCpKZs/6Dxqp0E/U+uw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-			"integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+			"integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.15.0",
-				"@babel/types": "^7.15.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/highlight": {
@@ -331,30 +354,30 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-			"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+			"version": "7.15.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+			"integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
-			"integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.15.4.tgz",
+			"integrity": "sha512-eBnpsl9tlhPhpI10kU06JHnrYXwg3+V6CaP2idsCXNef0aeslpqyITXQ74Vfk5uHgY7IG7XP0yIH8b42KSzHog==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
 				"@babel/plugin-proposal-optional-chaining": "^7.14.5"
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
-			"integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
+			"integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-remap-async-to-generator": "^7.14.5",
+				"@babel/helper-remap-async-to-generator": "^7.15.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			}
 		},
@@ -369,12 +392,12 @@
 			}
 		},
 		"@babel/plugin-proposal-class-static-block": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
-			"integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.15.4.tgz",
+			"integrity": "sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			}
@@ -484,13 +507,13 @@
 			}
 		},
 		"@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.15.4.tgz",
+			"integrity": "sha512-X0UTixkLf0PCCffxgu5/1RQyGGbgZuKoI+vXP4iSbJSYwPb7hu06omsFGBvQ9lJEvwgrxHdS8B5nbfcd8GyUNA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			}
@@ -706,18 +729,26 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.9.tgz",
-			"integrity": "sha512-NfZpTcxU3foGWbl4wxmZ35mTsYJy8oQocbeIMoDAGGFarAmSQlL+LWMkDx/tj6pNotpbX3rltIA4dprgAPOq5A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+			"integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
+				"@babel/helper-annotate-as-pure": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -768,9 +799,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
-			"integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+			"integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
@@ -816,27 +847,27 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
-			"integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+			"integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.15.0",
+				"@babel/helper-module-transforms": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-simple-access": "^7.14.8",
+				"@babel/helper-simple-access": "^7.15.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
-			"integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.15.4.tgz",
+			"integrity": "sha512-fJUnlQrl/mezMneR72CKCgtOoahqGJNVKpompKwzv3BrEXdlPspTcyxrZ1XmDTIr9PpULrgEQo3qNKp6dW7ssw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.14.5",
-				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-validator-identifier": "^7.14.5",
+				"@babel/helper-validator-identifier": "^7.14.9",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
@@ -879,9 +910,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
-			"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+			"integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
@@ -1033,12 +1064,12 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz",
-			"integrity": "sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.4.tgz",
+			"integrity": "sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.15.0",
+				"@babel/helper-create-class-features-plugin": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/plugin-syntax-typescript": "^7.14.5"
 			}
@@ -1063,19 +1094,19 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
-			"integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.4.tgz",
+			"integrity": "sha512-4f2nLw+q6ht8gl3sHCmNhmA5W6b1ItLzbH3UrKuJxACHr2eCpk96jwjrAfCAaXaaVwTQGnyUYHY2EWXJGt7TUQ==",
 			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.15.0",
-				"@babel/helper-compilation-targets": "^7.15.0",
+				"@babel/helper-compilation-targets": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/helper-validator-option": "^7.14.5",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-				"@babel/plugin-proposal-async-generator-functions": "^7.14.9",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.15.4",
 				"@babel/plugin-proposal-class-properties": "^7.14.5",
-				"@babel/plugin-proposal-class-static-block": "^7.14.5",
+				"@babel/plugin-proposal-class-static-block": "^7.15.4",
 				"@babel/plugin-proposal-dynamic-import": "^7.14.5",
 				"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
 				"@babel/plugin-proposal-json-strings": "^7.14.5",
@@ -1086,7 +1117,7 @@
 				"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
 				"@babel/plugin-proposal-optional-chaining": "^7.14.5",
 				"@babel/plugin-proposal-private-methods": "^7.14.5",
-				"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+				"@babel/plugin-proposal-private-property-in-object": "^7.15.4",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1105,25 +1136,25 @@
 				"@babel/plugin-transform-arrow-functions": "^7.14.5",
 				"@babel/plugin-transform-async-to-generator": "^7.14.5",
 				"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-				"@babel/plugin-transform-block-scoping": "^7.14.5",
-				"@babel/plugin-transform-classes": "^7.14.9",
+				"@babel/plugin-transform-block-scoping": "^7.15.3",
+				"@babel/plugin-transform-classes": "^7.15.4",
 				"@babel/plugin-transform-computed-properties": "^7.14.5",
 				"@babel/plugin-transform-destructuring": "^7.14.7",
 				"@babel/plugin-transform-dotall-regex": "^7.14.5",
 				"@babel/plugin-transform-duplicate-keys": "^7.14.5",
 				"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-				"@babel/plugin-transform-for-of": "^7.14.5",
+				"@babel/plugin-transform-for-of": "^7.15.4",
 				"@babel/plugin-transform-function-name": "^7.14.5",
 				"@babel/plugin-transform-literals": "^7.14.5",
 				"@babel/plugin-transform-member-expression-literals": "^7.14.5",
 				"@babel/plugin-transform-modules-amd": "^7.14.5",
-				"@babel/plugin-transform-modules-commonjs": "^7.15.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.14.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.15.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.15.4",
 				"@babel/plugin-transform-modules-umd": "^7.14.5",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
 				"@babel/plugin-transform-new-target": "^7.14.5",
 				"@babel/plugin-transform-object-super": "^7.14.5",
-				"@babel/plugin-transform-parameters": "^7.14.5",
+				"@babel/plugin-transform-parameters": "^7.15.4",
 				"@babel/plugin-transform-property-literals": "^7.14.5",
 				"@babel/plugin-transform-regenerator": "^7.14.5",
 				"@babel/plugin-transform-reserved-words": "^7.14.5",
@@ -1135,7 +1166,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.14.5",
 				"@babel/plugin-transform-unicode-regex": "^7.14.5",
 				"@babel/preset-modules": "^0.1.4",
-				"@babel/types": "^7.15.0",
+				"@babel/types": "^7.15.4",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
 				"babel-plugin-polyfill-corejs3": "^0.2.2",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
@@ -1190,18 +1221,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+			"integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.15.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
-			"integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz",
+			"integrity": "sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.16.0",
@@ -1209,37 +1240,45 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-			"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+			"integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.14.5",
-				"@babel/parser": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-			"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+			"integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.15.0",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-hoist-variables": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
-				"@babel/parser": "^7.15.0",
-				"@babel/types": "^7.15.0",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-			"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+			"integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.14.9",
@@ -1260,21 +1299,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			}
-		},
-		"@dekode/eslint-plugin": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@dekode/eslint-plugin/-/eslint-plugin-0.0.1.tgz",
-			"integrity": "sha512-jBtS3lYNmkbo/DTFra8ZxNqe08V0TjM5/b4V65+0lCb4qIgMHramaUSGDy8m7cj4xJ7smGXqdVTvS+laBqZM7g==",
-			"dev": true,
-			"requires": {
-				"babel-eslint": "10.1.0",
-				"confusing-browser-globals": "1.0.9",
-				"eslint-plugin-import": "2.21.2",
-				"eslint-plugin-jsx-a11y": "6.3.1",
-				"eslint-plugin-react": "7.20.0",
-				"eslint-plugin-react-hooks": "4.0.4",
-				"merge": "1.2.1"
 			}
 		},
 		"@dekode/stylelint-config": {
@@ -1752,12 +1776,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1778,14 +1796,6 @@
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.4",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/test-result": {
@@ -1874,12 +1884,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
@@ -1984,9 +1988,9 @@
 			}
 		},
 		"@polka/url": {
-			"version": "1.0.0-next.17",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.17.tgz",
-			"integrity": "sha512-0p1rCgM3LLbAdwBnc7gqgnvjHg9KpbhcSphergHShlkWz8EdPawoMJ3/VbezI0mGC5eKCDzMaPgF9Yca6cKvrg==",
+			"version": "1.0.0-next.20",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
+			"integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -2212,9 +2216,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.1.15",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-			"integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+			"version": "7.1.16",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+			"integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2343,9 +2347,9 @@
 			"dev": true
 		},
 		"@types/mdast": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.9.tgz",
-			"integrity": "sha512-IUlIhG2KNPjOEuXIblTjovD1XW8HPGeulA12nEyc6xhO4Yrrcs+xczAl4ucR3cpwVlE+vb2x9Z7pRmVP4bUHng==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
+			"integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "*"
@@ -2364,9 +2368,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.7.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-			"integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
+			"version": "16.7.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
+			"integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -2400,9 +2404,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.14.14",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
-			"integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
+			"version": "16.14.15",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.15.tgz",
+			"integrity": "sha512-jOxlBV9RGZhphdeqJTCv35VZOkjY+XIEY2owwSk84BNDdDv2xS6Csj6fhi+B/q30SR9Tz8lDNt/F2Z5RF3TrRg==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -2450,14 +2454,6 @@
 			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"@types/unist": {
@@ -2478,14 +2474,6 @@
 				"@types/webpack-sources": "*",
 				"anymatch": "^3.0.0",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"@types/webpack-sources": {
@@ -2533,115 +2521,85 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
-			"integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.0.tgz",
+			"integrity": "sha512-iPKZTZNavAlOhfF4gymiSuUkgLne/nh5Oz2/mdiUmuZVD42m9PapnCnzjxuDsnpnbH3wT5s2D8bw6S39TC6GNw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.30.0",
-				"@typescript-eslint/scope-manager": "4.30.0",
+				"@typescript-eslint/experimental-utils": "4.31.0",
+				"@typescript-eslint/scope-manager": "4.31.0",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
-			"integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.0.tgz",
+			"integrity": "sha512-Hld+EQiKLMppgKKkdUsLeVIeEOrwKc2G983NmznY/r5/ZtZCDvIOXnXtwqJIgYz/ymsy7n7RGvMyrzf1WaSQrw==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.30.0",
-				"@typescript-eslint/types": "4.30.0",
-				"@typescript-eslint/typescript-estree": "4.30.0",
+				"@typescript-eslint/scope-manager": "4.31.0",
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/typescript-estree": "4.31.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
-			"integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.0.tgz",
+			"integrity": "sha512-oWbzvPh5amMuTmKaf1wp0ySxPt2ZXHnFQBN2Szu1O//7LmOvgaKTCIDNLK2NvzpmVd5A2M/1j/rujBqO37hj3w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.30.0",
-				"@typescript-eslint/types": "4.30.0",
-				"@typescript-eslint/typescript-estree": "4.30.0",
+				"@typescript-eslint/scope-manager": "4.31.0",
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/typescript-estree": "4.31.0",
 				"debug": "^4.3.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-			"integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz",
+			"integrity": "sha512-LJ+xtl34W76JMRLjbaQorhR0hfRAlp3Lscdiz9NeI/8i+q0hdBZ7BsiYieLoYWqy+AnRigaD3hUwPFugSzdocg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.30.0",
-				"@typescript-eslint/visitor-keys": "4.30.0"
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/visitor-keys": "4.31.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-			"integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.0.tgz",
+			"integrity": "sha512-9XR5q9mk7DCXgXLS7REIVs+BaAswfdHhx91XqlJklmqWpTALGjygWVIb/UnLh4NWhfwhR5wNe1yTyCInxVhLqQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-			"integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.0.tgz",
+			"integrity": "sha512-QHl2014t3ptg+xpmOSSPn5hm4mY8D4s97ftzyk9BZ8RxYQ3j73XcwuijnJ9cMa6DO4aLXeo8XS3z1omT9LA/Eg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.30.0",
-				"@typescript-eslint/visitor-keys": "4.30.0",
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/visitor-keys": "4.31.0",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-			"integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz",
+			"integrity": "sha512-HUcRp2a9I+P21+O21yu3ezv3GEPGjyGiXoEUQwZXjR8UxRApGeLyWH4ZIIUSalE28aG4YsV6GjtaAVB3QKOu0w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.30.0",
+				"@typescript-eslint/types": "4.31.0",
 				"eslint-visitor-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -2942,223 +2900,6 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"axe-core": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
-					"integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
-					"dev": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"eslint-plugin-import": {
-					"version": "2.24.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
-					"integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.1.3",
-						"array.prototype.flat": "^1.2.4",
-						"debug": "^2.6.9",
-						"doctrine": "^2.1.0",
-						"eslint-import-resolver-node": "^0.3.6",
-						"eslint-module-utils": "^2.6.2",
-						"find-up": "^2.0.0",
-						"has": "^1.0.3",
-						"is-core-module": "^2.6.0",
-						"minimatch": "^3.0.4",
-						"object.values": "^1.1.4",
-						"pkg-up": "^2.0.0",
-						"read-pkg-up": "^3.0.0",
-						"resolve": "^1.20.0",
-						"tsconfig-paths": "^3.11.0"
-					}
-				},
-				"eslint-plugin-jsx-a11y": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
-					"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.11.2",
-						"aria-query": "^4.2.2",
-						"array-includes": "^3.1.1",
-						"ast-types-flow": "^0.0.7",
-						"axe-core": "^4.0.2",
-						"axobject-query": "^2.2.0",
-						"damerau-levenshtein": "^1.0.6",
-						"emoji-regex": "^9.0.0",
-						"has": "^1.0.3",
-						"jsx-ast-utils": "^3.1.0",
-						"language-tags": "^1.0.5"
-					}
-				},
-				"eslint-plugin-react": {
-					"version": "7.25.1",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-					"integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.1.3",
-						"array.prototype.flatmap": "^1.2.4",
-						"doctrine": "^2.1.0",
-						"estraverse": "^5.2.0",
-						"has": "^1.0.3",
-						"jsx-ast-utils": "^2.4.1 || ^3.0.0",
-						"minimatch": "^3.0.4",
-						"object.entries": "^1.1.4",
-						"object.fromentries": "^2.0.4",
-						"object.values": "^1.1.4",
-						"prop-types": "^15.7.2",
-						"resolve": "^2.0.0-next.3",
-						"string.prototype.matchall": "^4.0.5"
-					},
-					"dependencies": {
-						"resolve": {
-							"version": "2.0.0-next.3",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
-							"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
-							"dev": true,
-							"requires": {
-								"is-core-module": "^2.2.0",
-								"path-parse": "^1.0.6"
-							}
-						}
-					}
-				},
-				"eslint-plugin-react-hooks": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-					"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-					"dev": true
-				},
-				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-					"dev": true
-				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"jsx-ast-utils": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-					"integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.1.2",
-						"object.assign": "^4.1.2"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"tsconfig-paths": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-					"integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
-					"dev": true,
-					"requires": {
-						"@types/json5": "^0.0.29",
-						"json5": "^1.0.1",
-						"minimist": "^1.2.0",
-						"strip-bom": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@wordpress/jest-console": {
@@ -3329,6 +3070,15 @@
 						"strip-bom": "^2.0.0"
 					}
 				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -3349,10 +3099,10 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
 				"read-pkg": {
@@ -3756,14 +3506,6 @@
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001255",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-					"integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
-					"dev": true
-				}
 			}
 		},
 		"aws-sign2": {
@@ -3779,9 +3521,9 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.5.6",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
-			"integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
+			"integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
 			"dev": true
 		},
 		"axios": {
@@ -3811,6 +3553,14 @@
 				"@babel/types": "^7.7.0",
 				"eslint-visitor-keys": "^1.0.0",
 				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
 			}
 		},
 		"babel-jest": {
@@ -3892,15 +3642,6 @@
 				"schema-utils": "^2.6.5"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
 				"loader-utils": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
@@ -4294,14 +4035,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.8",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001251",
+				"caniuse-lite": "^1.0.30001254",
 				"colorette": "^1.3.0",
-				"electron-to-chromium": "^1.3.811",
+				"electron-to-chromium": "^1.3.830",
 				"escalade": "^3.1.1",
 				"node-releases": "^1.1.75"
 			}
@@ -4432,9 +4173,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001251",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+			"version": "1.0.30001255",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+			"integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -4461,6 +4202,17 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"char-regex": {
@@ -4648,9 +4400,9 @@
 					"dev": true
 				},
 				"domutils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-					"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -4841,9 +4593,9 @@
 			"dev": true
 		},
 		"colorette": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-			"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+			"integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -4897,12 +4649,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
 		"connect": {
 			"version": "3.6.6",
 			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -4938,12 +4684,6 @@
 			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
 			"dev": true
 		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-			"dev": true
-		},
 		"continuable-cache": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
@@ -4972,18 +4712,18 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.16.2",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-			"integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
+			"integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.16.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
-			"integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.2.tgz",
+			"integrity": "sha512-lHnt7A1Oqplebl5i0MrQyFv/yyEzr9p29OjlkcsFRDDgHwwQyVckfRGJ790qzXhkwM8ba4SFHHa2sO+T5f1zGg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.7",
+				"browserslist": "^4.16.8",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -4996,9 +4736,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.16.2",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
-			"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.2.tgz",
+			"integrity": "sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -5018,26 +4758,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				}
 			}
 		},
 		"cross-spawn": {
@@ -5076,9 +4796,9 @@
 			"dev": true
 		},
 		"css-declaration-sorter": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
-			"integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.3.tgz",
+			"integrity": "sha512-SvjQjNRZgh4ULK1LDJ2AduPKUKxIqmtU7ZAyi47BTV+M90Qvxr9AB6lKlLbDUfXqI9IQeYA8LbAsCZPpJEV3aA==",
 			"dev": true,
 			"requires": {
 				"timsort": "^0.3.0"
@@ -5098,17 +4818,6 @@
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.1.0",
 				"semver": "^7.3.5"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"css-select": {
@@ -5137,14 +4846,6 @@
 			"requires": {
 				"mdn-data": "2.0.4",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"css-what": {
@@ -5237,12 +4938,6 @@
 					"version": "2.0.14",
 					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
 					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
@@ -5370,9 +5065,9 @@
 			"dev": true
 		},
 		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
 		"deepmerge": {
@@ -5533,14 +5228,6 @@
 			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				}
 			}
 		},
 		"discontinuous-range": {
@@ -5556,13 +5243,12 @@
 			"dev": true
 		},
 		"doctrine": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"isarray": "^1.0.0"
+				"esutils": "^2.0.2"
 			}
 		},
 		"dom-serializer": {
@@ -5607,9 +5293,9 @@
 			}
 		},
 		"domhandler": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-			"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+			"integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.2.0"
@@ -5680,9 +5366,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.814",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
-			"integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
+			"version": "1.3.832",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.832.tgz",
+			"integrity": "sha512-x7lO8tGoW0CyV53qON4Lb5Rok9ipDelNdBIAiYUZ03dqy4u9vohMM1qV047+s/hiyJiqUWX/3PNwkX3kexX5ig==",
 			"dev": true
 		},
 		"emittery": {
@@ -5905,22 +5591,23 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.18.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-			"integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+			"version": "1.18.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+			"integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.1.1",
+				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.2",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.3",
+				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.1",
-				"is-regex": "^1.1.3",
-				"is-string": "^1.0.6",
+				"is-regex": "^1.1.4",
+				"is-string": "^1.0.7",
 				"object-inspect": "^1.11.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
@@ -6018,13 +5705,6 @@
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
 				},
 				"type-check": {
 					"version": "0.3.2",
@@ -6171,12 +5851,6 @@
 						}
 					}
 				},
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				},
 				"globals": {
 					"version": "13.11.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
@@ -6203,15 +5877,6 @@
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -6303,24 +5968,26 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.21.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz",
-			"integrity": "sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==",
+			"version": "2.24.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+			"integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.3",
-				"eslint-module-utils": "^2.6.0",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.6",
+				"eslint-module-utils": "^2.6.2",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.6.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
-				"tsconfig-paths": "^3.9.0"
+				"object.values": "^1.1.4",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
+				"tsconfig-paths": "^3.11.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -6364,35 +6031,24 @@
 				"regextras": "^0.7.1",
 				"semver": "^7.3.5",
 				"spdx-expression-parse": "^3.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
-			"integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+			"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.10.2",
+				"@babel/runtime": "^7.11.2",
 				"aria-query": "^4.2.2",
 				"array-includes": "^3.1.1",
 				"ast-types-flow": "^0.0.7",
-				"axe-core": "^3.5.4",
-				"axobject-query": "^2.1.2",
+				"axe-core": "^4.0.2",
+				"axobject-query": "^2.2.0",
 				"damerau-levenshtein": "^1.0.6",
 				"emoji-regex": "^9.0.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^3.1.0",
 				"language-tags": "^1.0.5"
 			}
 		},
@@ -6415,39 +6071,48 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.0.tgz",
-			"integrity": "sha512-rqe1abd0vxMjmbPngo4NaYxTcR3Y4Hrmc/jg4T+sYz63yqlmJRknpEQfmWY+eDWPuMmix6iUIK+mv0zExjeLgA==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
+			"integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
+				"array-includes": "^3.1.3",
+				"array.prototype.flatmap": "^1.2.4",
 				"doctrine": "^2.1.0",
+				"estraverse": "^5.2.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.2.3",
-				"object.entries": "^1.1.1",
-				"object.fromentries": "^2.0.2",
-				"object.values": "^1.1.1",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.0.4",
+				"object.entries": "^1.1.4",
+				"object.fromentries": "^2.0.4",
+				"object.values": "^1.1.4",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.15.1",
-				"string.prototype.matchall": "^4.0.2",
-				"xregexp": "^4.3.0"
+				"resolve": "^2.0.0-next.3",
+				"string.prototype.matchall": "^4.0.5"
 			},
 			"dependencies": {
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "2.0.0-next.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+					"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2"
+						"is-core-module": "^2.2.0",
+						"path-parse": "^1.0.6"
 					}
 				}
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz",
-			"integrity": "sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -6467,20 +6132,12 @@
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true
 		},
 		"espree": {
@@ -6492,6 +6149,14 @@
 				"acorn": "^7.4.0",
 				"acorn-jsx": "^5.3.1",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -6597,6 +6262,12 @@
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
 					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -6988,9 +6659,9 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
@@ -7188,9 +6859,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-			"integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+			"integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
 			"dev": true
 		},
 		"for-in": {
@@ -7356,6 +7027,16 @@
 				"pump": "^3.0.0"
 			}
 		},
+		"get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			}
+		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -7439,10 +7120,13 @@
 			}
 		},
 		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
+			}
 		},
 		"globby": {
 			"version": "11.0.4",
@@ -7721,9 +7405,9 @@
 					"dev": true
 				},
 				"domutils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-					"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -8451,14 +8135,6 @@
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-reports": {
@@ -9404,18 +9080,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9720,15 +9384,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10028,9 +9683,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 					"dev": true
 				}
 			}
@@ -10084,12 +9739,12 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.0"
 			}
 		},
 		"jsonc-parser": {
@@ -10120,13 +9775,13 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-			"integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+			"integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"object.assign": "^4.1.0"
+				"array-includes": "^3.1.2",
+				"object.assign": "^4.1.2"
 			}
 		},
 		"kind-of": {
@@ -10224,15 +9879,27 @@
 			"dev": true
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				}
 			}
 		},
 		"loader-runner": {
@@ -10250,6 +9917,17 @@
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
 				"json5": "^2.1.2"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				}
 			}
 		},
 		"localtunnel": {
@@ -10774,18 +10452,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10838,12 +10504,6 @@
 					"dev": true
 				}
 			}
-		},
-		"merge": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-			"dev": true
 		},
 		"merge-deep": {
 			"version": "3.0.3",
@@ -10933,9 +10593,9 @@
 			"dev": true
 		},
 		"mini-css-extract-plugin": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.0.tgz",
-			"integrity": "sha512-91HeVHbq7PUJ4TwOuMTlFWfVWrLqf3SF0PlEDPV+wtgsfxrMebN9LLzflyQqdKLp4/H3PexRB1WLKsCqpWKkxQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.2.tgz",
+			"integrity": "sha512-eUjQ/q1rQIeHWgIx7ny/DNgXHcMXHdBwgrZQK7Ev8dbR+HxhroFM2Cb6kMiswOYaq05IRJhPuQqXWUABIjjA3g==",
 			"dev": true,
 			"requires": {
 				"schema-utils": "^3.1.0"
@@ -11148,16 +10808,6 @@
 				"which": "^2.0.2"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11186,6 +10836,14 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-path": {
@@ -11293,33 +10951,6 @@
 					"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
 					"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
 					"dev": true
-				},
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -11650,12 +11281,15 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
 			}
 		},
 		"parse-passwd": {
@@ -11734,13 +11368,10 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"dev": true,
-			"requires": {
-				"pify": "^2.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -11761,9 +11392,9 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true
 		},
 		"pinkie": {
@@ -12021,21 +11652,6 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -12048,17 +11664,6 @@
 				"cosmiconfig": "^7.0.0",
 				"klona": "^2.0.4",
 				"semver": "^7.3.5"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"postcss-media-minmax": {
@@ -12346,21 +11951,6 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -12384,21 +11974,6 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -12420,21 +11995,6 @@
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -12474,21 +12034,6 @@
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -12556,9 +12101,9 @@
 					"dev": true
 				},
 				"domutils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-					"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -12581,23 +12126,17 @@
 						"boolbase": "^1.0.0"
 					}
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
 				"svgo": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.4.0.tgz",
-					"integrity": "sha512-W25S1UUm9Lm9VnE0TvCzL7aso/NCzDEaXLaElCUO/KaVitw0+IBicSVfM1L1c0YHK5TOFh73yQ2naCpVHEQ/OQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
+					"integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
 					"dev": true,
 					"requires": {
 						"@trysound/sax": "0.1.1",
-						"colorette": "^1.2.2",
-						"commander": "^7.1.0",
+						"colorette": "^1.3.0",
+						"commander": "^7.2.0",
 						"css-select": "^4.1.3",
-						"css-tree": "^1.1.2",
+						"css-tree": "^1.1.3",
 						"csso": "^4.2.0",
 						"stable": "^0.1.8"
 					}
@@ -13029,27 +12568,46 @@
 			"dev": true,
 			"requires": {
 				"pify": "^2.3.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				}
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -13639,9 +13197,9 @@
 			}
 		},
 		"sass": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
-			"integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.39.0.tgz",
+			"integrity": "sha512-F4o+RhJkNOIG0b6QudYU8c78ZADKZjKDk5cyrf8XTKWfrgbtyVVXImFstJrc+1pkQDCggyidIOytq6gS4gCCZg==",
 			"dev": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0"
@@ -13694,10 +13252,13 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"send": {
 			"version": "0.16.2",
@@ -13966,12 +13527,12 @@
 			"dev": true
 		},
 		"sirv": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.14.tgz",
-			"integrity": "sha512-czTFDFjK9lXj0u9mJ3OmJoXFztoilYS+NdRPcJoT182w44wSEkHSiO7A2517GLJ8wKM4GjCm2OXE66Dhngbzjg==",
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.17.tgz",
+			"integrity": "sha512-qx9go5yraB7ekT7bCMqUHJ5jEaOC/GXBxUWv+jeWnb7WzHUFdcQPGWk7YmAwFBaQBrogpuSqd/azbC2lZRqqmw==",
 			"dev": true,
 			"requires": {
-				"@polka/url": "^1.0.0-next.17",
+				"@polka/url": "^1.0.0-next.20",
 				"mime": "^2.3.1",
 				"totalist": "^1.0.0"
 			}
@@ -14072,6 +13633,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				}
 			}
@@ -14278,9 +13845,9 @@
 			"dev": true
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true
 		},
 		"source-map-js": {
@@ -14332,14 +13899,6 @@
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"source-map-url": {
@@ -14888,18 +14447,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -15010,30 +14557,6 @@
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
 				"type-fest": {
 					"version": "0.18.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -15092,21 +14615,6 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -15142,28 +14650,13 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+			"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
@@ -15317,9 +14810,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-			"integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
+			"integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -15336,17 +14829,17 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-			"integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.3.tgz",
+			"integrity": "sha512-eDbuaDlXhVaaoKuLD3DTNTozKqln6xOG6Us0SzlKG5tNlazG+/cdl8pm9qiF1Di89iWScTI0HcO+CDcf2dkXiw==",
 			"dev": true,
 			"requires": {
-				"jest-worker": "^27.0.2",
+				"jest-worker": "^27.0.6",
 				"p-limit": "^3.1.0",
-				"schema-utils": "^3.0.0",
+				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0",
 				"source-map": "^0.6.1",
-				"terser": "^5.7.0"
+				"terser": "^5.7.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -15356,9 +14849,9 @@
 					"dev": true
 				},
 				"jest-worker": {
-					"version": "27.0.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"version": "27.1.1",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.1.tgz",
+					"integrity": "sha512-XJKCL7tu+362IUYTWvw8+3S75U7qMiYiRU6u5yqscB48bTvzwN6i8L/7wVTXiFLwkRsxARNM7TISnTvcgv9hxA==",
 					"dev": true,
 					"requires": {
 						"@types/node": "*",
@@ -15385,12 +14878,6 @@
 						"ajv": "^6.12.5",
 						"ajv-keywords": "^3.5.2"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
 				},
 				"supports-color": {
 					"version": "8.1.1",
@@ -15516,9 +15003,9 @@
 			}
 		},
 		"tmpl": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
 		},
 		"to-array": {
@@ -15634,12 +15121,13 @@
 			"dev": true
 		},
 		"tsconfig-paths": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-			"integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+			"integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
 			"dev": true,
 			"requires": {
-				"json5": "^2.2.0",
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
 				"minimist": "^1.2.0",
 				"strip-bom": "^3.0.0"
 			}
@@ -16136,9 +15624,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.51.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
-			"integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.52.0.tgz",
+			"integrity": "sha512-yRZOat8jWGwBwHpco3uKQhVU7HYaNunZiJ4AkAVQkPCUGoZk/tiIXiwG+8HIy/F+qsiZvSOa+GLQOj3q5RKRYg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
@@ -16168,9 +15656,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 					"dev": true
 				},
 				"schema-utils": {
@@ -16210,15 +15698,15 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 					"dev": true
 				},
 				"acorn-walk": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-					"integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -16444,14 +15932,6 @@
 			"requires": {
 				"source-list-map": "^2.0.1",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"websocket-driver": {
@@ -16593,9 +16073,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-			"integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+			"integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
 			"dev": true
 		},
 		"xml-name-validator": {
@@ -16615,15 +16095,6 @@
 			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
 			"integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
 			"dev": true
-		},
-		"xregexp": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
-			"integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime-corejs3": "^7.12.1"
-			}
 		},
 		"y18n": {
 			"version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"scripts": {
 		"start": "wp-scripts start",
 		"build": "wp-scripts build",
+		"format": "wp-scripts format .",
 		"check-engines": "wp-scripts check-engines",
 		"lint": "npm run lint:js && npm run lint:css",
 		"lint:css": "wp-scripts lint-style",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 		"@teft/wordpress": "^0.4.0"
 	},
 	"devDependencies": {
-		"@dekode/eslint-plugin": "0.0.1",
 		"@dekode/stylelint-config": "1.0.1",
 		"@wordpress/eslint-plugin": "9.1.1",
 		"@wordpress/scripts": "18.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies, @wordpress/dependency-group */
+
 /**
  * External dependencies
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,16 +22,19 @@ function getBuildPath( name ) {
 async function getEntries() {
 	const entries = {};
 
-	let dirs = await glob( [
-		'./packages/mu-plugins/*',
-		'./packages/plugins/*',
-		'./packages/themes/*',
-	], { onlyDirectories: true } );
+	let dirs = await glob(
+		[
+			'./packages/mu-plugins/*',
+			'./packages/plugins/*',
+			'./packages/themes/*',
+		],
+		{ onlyDirectories: true }
+	);
 
 	// Only include directories that contains a entry-files.json file.
-	dirs = dirs.filter( ( dir ) => (
+	dirs = dirs.filter( ( dir ) =>
 		fs.existsSync( path.resolve( dir, 'entry-files.json' ) )
-	) );
+	);
 
 	dirs.forEach( ( dir ) => {
 		const entryFiles = require( `${ dir }/entry-files.json` ); // eslint-disable-line
@@ -41,7 +44,9 @@ async function getEntries() {
 			 * MiniCSSExtractPlugin handles css files. Rename them and ignore in
 			 * IgnoreEmitPlugin to allow as direct entry files.
 			 */
-			entries[ `${ dir }|${ entry.replace( '.css', '.css-entry-file' ) }` ] = `${ dir }/src/${ entry }`;
+			entries[
+				`${ dir }|${ entry.replace( '.css', '.css-entry-file' ) }`
+			] = `${ dir }/src/${ entry }`;
 		} );
 	} );
 
@@ -68,7 +73,12 @@ const config = {
 					chunks: 'all',
 					enforce: true,
 					name( _, chunks ) {
-						return getBuildPath( chunks[ 0 ].name.replace( '.css-entry-file', '.css' ) );
+						return getBuildPath(
+							chunks[ 0 ].name.replace(
+								'.css-entry-file',
+								'.css'
+							)
+						);
 					},
 				},
 				default: false,
@@ -92,7 +102,7 @@ if ( 'true' === process.env.BROWSER_SYNC_ENABLE ) {
 			proxy: process.env.BROWSER_SYNC_PROXY ?? process.env.WP_HOME,
 			port: process.env.BROWSER_SYNC_PORT ?? 3002,
 			https: 'true' === process.env.BROWSER_SYNC_HTTPS,
-		} ),
+		} )
 	);
 }
 


### PR DESCRIPTION
Run all files trough the format function in wp-scripts (prettier). Also updated the eslint config to use recommended wp (that supports the new style after format is runned)

This ensures a consistent style in files.

Next step (if merged) will be to add husky and lint-staged to run the staged files automatically trough the format script before push.