### PR TITLE
Create a shared `components` directory for projects to lean on

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"baseUrl": "packages"
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,13 @@ const config = {
 			},
 		},
 	},
+	resolve: {
+		...defaultConfig.resolve,
+		alias: {
+			...defaultConfig.resolve.alias,
+			components: path.resolve( __dirname, 'packages', 'components' )
+		}
+	},
 	plugins: [
 		new MiniCSSExtractPlugin( { filename: '[name]' } ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,8 +91,8 @@ const config = {
 		...defaultConfig.resolve,
 		alias: {
 			...defaultConfig.resolve.alias,
-			components: path.resolve( __dirname, 'packages', 'components' )
-		}
+			components: path.resolve( __dirname, 'packages', 'components' ),
+		},
 	},
 	plugins: [
 		new MiniCSSExtractPlugin( { filename: '[name]' } ),


### PR DESCRIPTION
Projects currently have to cross-reference various plugins or set up convoluted relative paths to use shared components.

By setting a standard for the use of `packages/components` as a place for these shared packages, and extending the webpack resolvers, we can now quickly reference them without worrying about path-relationships regardless of where in a project the shared components are used.

Example folder structure:
```
- project-base
  |- packages
     |- components
        |- image
           |- index.js
        |- wrapper
           |- index.js
     |- plugins
        |- block-plugin
           |- src
              |- index.js
     |- themes
        |- project-theme
           |- src
              |- Header
                 |- index.js
                 |- style.css
```

## Before this change
**block-plugin/src/index.js**
```js
import Image from '../../../components/image';
```

**project-theme/src/Header/index.js**
```js
import Image from '../../../../components/image';
```

As can be seen here, the relative paths differ, and if you refactor anything, you end up having to look across a wide project structure to (hopefully) not break anything.

## After the change
**block-plugin/src/index.js**
```js
import Image from 'components/image';
```

**project-theme/src/Header/index.js**
```js
import Image from 'components/image';
```

Take note that we start with just `components` without any indicators before it, this allows code to still have a sub-directory named `components` for things shared within that plugin or theme alone, and it can then reference this using `./components` (or any other relative indicator.

## CSS Implications
This also makes shared components available in CSS files, although uses a slightly different format. It does this by providing a `jsconfig.json` file declaring a shared `baseUrl` for anything that isn't found by normal means, in this case `packages` (it does not go all the way into `components`, due to how the PostCSS loader works).

That means a shared library can now be used in the `.css` files as well

## Before this change
**project-theme/src/style.css**
```css
@import '../../../components/image/style.css';
```

## After this change
**project-theme/src/style.css**
```css
@import 'components/images/style.css';
```

(if we chose to set the `baseUrl` to `packages/components`, then the shared component use in CSS would be `images/style.css`, loosing context I feel).