### PR TITLE
Webpack: Add support for non-default style-file names.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ async function getEntries() {
 			 * IgnoreEmitPlugin to allow as direct entry files.
 			 */
 			entries[
-				`${ dir }|${ entry.replace( '.css', '.css-entry-file' ) }`
+				`${ dir }|${ entry.replace( /.(sc|sa|c)ss/, '.css-entry-file' ) }`
 			] = `${ dir }/src/${ entry }`;
 		} );
 	} );
@@ -71,7 +71,7 @@ const config = {
 			cacheGroups: {
 				style: {
 					type: 'css/mini-extract',
-					test: /[\\/]style(\.module)?\.(sc|sa|c)ss$/,
+					test: /[\\/].+?\.(sc|sa|c)ss$/,
 					chunks: 'all',
 					enforce: true,
 					name( _, chunks ) {


### PR DESCRIPTION
This expands the support for `entry-files.json` to also respect any style-file, and not just `style.css` and `style.module.css`.

It also extends the support to not care which preprocessor you wish to use, so long as `@wordpress/scripts` supports it.
This is especially important to ensure smooth upgrades from older projects, saving them from rewriting large chunks of code, but instead making it a drop-in upgrade of the projects base structure.

This fixes #290