### PR TITLE
Use multi config setup and support relative paths for SCSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2850,6 +2850,14 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/jest-console": {
@@ -3137,6 +3145,12 @@
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3180,6 +3194,16 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
 			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
+		},
+		"adjust-sourcemap-loader": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+			"integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"regex-parser": "^2.2.11"
+			}
 		},
 		"after": {
 			"version": "0.8.2",
@@ -3236,6 +3260,12 @@
 			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
 			"dev": true
 		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -3282,6 +3312,48 @@
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"are-we-there-yet": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+			"integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+			"dev": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
 			}
 		},
 		"argparse": {
@@ -3446,6 +3518,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
 			"integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+			"dev": true
+		},
+		"async-foreach": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
 			"dev": true
 		},
 		"asynckit": {
@@ -4635,6 +4713,12 @@
 				"q": "^1.1.2"
 			}
 		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -4763,6 +4847,21 @@
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
 			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
 			"dev": true
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"console-table-printer": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.10.0.tgz",
+			"integrity": "sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==",
+			"dev": true,
+			"requires": {
+				"simple-wcswidth": "^1.0.1"
+			}
 		},
 		"continuable-cache": {
 			"version": "0.3.1",
@@ -5265,6 +5364,12 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
+		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -5593,6 +5698,12 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
 			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true
+		},
+		"env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
 			"dev": true
 		},
 		"envinfo": {
@@ -7020,6 +7131,15 @@
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7062,6 +7182,68 @@
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
 			"integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
 			"dev": true
+		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"gaze": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+			"dev": true,
+			"requires": {
+				"globule": "^1.0.0"
+			}
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -7234,6 +7416,17 @@
 			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
 		},
+		"globule": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.3.tgz",
+			"integrity": "sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==",
+			"dev": true,
+			"requires": {
+				"glob": "~7.1.1",
+				"lodash": "~4.17.10",
+				"minimatch": "~3.0.2"
+			}
+		},
 		"gonzales-pe": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
@@ -7362,6 +7555,12 @@
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -7610,12 +7809,6 @@
 			"version": "5.1.8",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
 			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-			"dev": true
-		},
-		"ignore-emit-webpack-plugin": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
-			"integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
 			"dev": true
 		},
 		"immutable": {
@@ -9717,6 +9910,12 @@
 				}
 			}
 		},
+		"js-base64": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+			"dev": true
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10992,6 +11191,25 @@
 				}
 			}
 		},
+		"minipass": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+			"integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			}
+		},
 		"mitt": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
@@ -11056,6 +11274,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"nan": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
 			"dev": true
 		},
 		"nanocolors": {
@@ -11131,6 +11355,44 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"dev": true
 		},
+		"node-gyp": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+			"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+			"dev": true,
+			"requires": {
+				"env-paths": "^2.2.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.3",
+				"nopt": "^5.0.0",
+				"npmlog": "^4.1.2",
+				"request": "^2.88.2",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.2",
+				"tar": "^6.0.2",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11175,6 +11437,292 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
 			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
+		},
+		"node-sass": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-6.0.1.tgz",
+			"integrity": "sha512-f+Rbqt92Ful9gX0cGtdYwjTrWAaGURgaK5rZCWOgCNyGWusFYHhbqCCBoFBeat+HKETOU02AyTxNhJV0YZf2jQ==",
+			"dev": true,
+			"requires": {
+				"async-foreach": "^0.1.3",
+				"chalk": "^1.1.1",
+				"cross-spawn": "^7.0.3",
+				"gaze": "^1.0.0",
+				"get-stdin": "^4.0.1",
+				"glob": "^7.0.3",
+				"lodash": "^4.17.15",
+				"meow": "^9.0.0",
+				"nan": "^2.13.2",
+				"node-gyp": "^7.1.0",
+				"npmlog": "^4.0.0",
+				"request": "^2.88.0",
+				"sass-graph": "2.2.5",
+				"stdout-stream": "^1.4.0",
+				"true-case-path": "^1.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+					"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"meow": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize": "^1.2.0",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"hosted-git-info": {
+							"version": "2.8.9",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+							"dev": true
+						},
+						"normalize-package-data": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"resolve": "^1.10.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						},
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.8.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+							"dev": true
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+					"dev": true
+				}
+			}
+		},
+		"nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
+			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -11322,6 +11870,18 @@
 				"path-key": "^2.0.0"
 			}
 		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
 		"nth-check": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -11335,6 +11895,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
 			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"dev": true
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
 		"nwsapi": {
@@ -11733,6 +12299,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
 			"dev": true
 		},
 		"picomatch": {
@@ -12531,12 +13103,6 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
-		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true
-		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -12589,6 +13155,12 @@
 					"dev": true
 				}
 			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -13048,6 +13620,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regex-parser": {
+			"version": "2.2.11",
+			"resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+			"integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+			"dev": true
+		},
 		"regexp.prototype.flags": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -13298,6 +13876,31 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"resolve-url-loader": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
+			"integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
+			"dev": true,
+			"requires": {
+				"adjust-sourcemap-loader": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"loader-utils": "^2.0.0",
+				"postcss": "^7.0.35",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.39",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+					"dev": true,
+					"requires": {
+						"picocolors": "^0.2.1",
+						"source-map": "^0.6.1"
+					}
+				}
+			}
 		},
 		"resp-modifier": {
 			"version": "6.0.2",
@@ -13574,6 +14177,157 @@
 				"chokidar": ">=3.0.0 <4.0.0"
 			}
 		},
+		"sass-graph": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+			"integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"lodash": "^4.0.0",
+				"scss-tokenizer": "^0.2.3",
+				"yargs": "^13.3.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"sass-loader": {
 			"version": "12.1.0",
 			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.1.0.tgz",
@@ -13618,6 +14372,27 @@
 				"@types/json-schema": "^7.0.5",
 				"ajv": "^6.12.4",
 				"ajv-keywords": "^3.5.2"
+			}
+		},
+		"scss-tokenizer": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+			"dev": true,
+			"requires": {
+				"js-base64": "^2.1.8",
+				"source-map": "^0.4.2"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
 			}
 		},
 		"semver": {
@@ -13899,6 +14674,12 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
+		},
+		"simple-wcswidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+			"integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
 			"dev": true
 		},
 		"sirv": {
@@ -14414,6 +15195,41 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
 			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
 			"dev": true
+		},
+		"stdout-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
 		},
 		"stream-throttle": {
 			"version": "0.1.3",
@@ -15175,6 +15991,34 @@
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true
 		},
+		"tar": {
+			"version": "6.1.11",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+			"dev": true,
+			"requires": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^3.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				}
+			}
+		},
 		"tar-fs": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
@@ -15520,6 +16364,15 @@
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
 			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
 			"dev": true
+		},
+		"true-case-path": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.2"
+			}
 		},
 		"tsconfig-paths": {
 			"version": "3.11.0",
@@ -16325,6 +17178,12 @@
 				}
 			}
 		},
+		"webpack-remove-empty-scripts": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-0.7.1.tgz",
+			"integrity": "sha512-9GWBe8TxKUYMalR84L99QjME6W0ptd/pupNqB4Ad4NazouwT+9QJLcfJjl7PDhR/L+qY9JHlzIGdgj0Vv1f3zA==",
+			"dev": true
+		},
 		"webpack-sources": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
@@ -16405,6 +17264,48 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
 		},
 		"wildcard": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"dotenv": "^10.0.0",
 		"fast-glob": "3.2.7",
 		"husky": "7.0.2",
-		"ignore-emit-webpack-plugin": "2.0.6",
 		"lint-staged": "11.1.2",
 		"postcss": "8.3.8",
 		"postcss-custom-media": "8.0.0",
@@ -26,7 +25,11 @@
 		"postcss-import": "14.0.2",
 		"postcss-media-minmax": "5.0.0",
 		"postcss-mixins": "8.1.0",
-		"postcss-nested": "5.0.6"
+		"postcss-nested": "5.0.6",
+		"node-sass": "~6.0.1",
+		"resolve-url-loader": "~4.0.0",
+		"console-table-printer": "~2.10.0",
+		"webpack-remove-empty-scripts": "~0.7.1"
 	},
 	"scripts": {
 		"prepare": "husky install",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,116 +3,246 @@
 /**
  * External dependencies
  */
-const glob = require( 'fast-glob' );
-const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
-const fs = require( 'fs' );
-const path = require( 'path' );
-const BrowserSyncPlugin = require( 'browser-sync-webpack-plugin' );
-const IgnoreEmitPlugin = require( 'ignore-emit-webpack-plugin' );
-require( 'dotenv' ).config();
+ const { sync: globSync } = require('fast-glob');
+ const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
+ const path = require('path');
+ const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
+ const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
+ const webpack = require('webpack');
+ const { Table } = require('console-table-printer');
+ require('dotenv').config();
 
-/**
- * WordPress dependencies
- */
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const defaultConfig = require( './node_modules/@wordpress/scripts/config/webpack.config' );
+ /**
+  * WordPress dependencies
+  */
+ const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
+ const defaultConfig = require('./node_modules/@wordpress/scripts/config/webpack.config');
 
-function getBuildPath( name ) {
-	return `${ name.split( '|' )[ 0 ] }/build/${ name.split( '|' )[ 1 ] }`;
-}
+ /**
+  * Patches config to use resolve-url-loader for relative paths in SCSS files
+  * It will be possible to use './images/png.png' inside the SCSS,
+  *
+  * All paths will be threated as relative to file, not project root.
+  */
+ for (const rule of defaultConfig.module.rules) {
+	 if ('any-filename-to-test.scss'.match(rule.test)) {
+		 const sassLoaderConfig = rule.use.pop();
 
-async function getEntries() {
-	const entries = {};
+		 // We mutate default config to change behaviour.
+		 rule.use = [
+			 ...rule.use,
+			 // resolve-url-loader should be executed right after sass-loader.
+			 {
+				 loader: require.resolve('resolve-url-loader'),
+				 options: {
+					 sourceMap: sassLoaderConfig.options.sourceMap,
+					 removeCR: true,
+				 },
+			 },
+			 {
+				 ...sassLoaderConfig,
+				 options: {
+					 ...sassLoaderConfig.options,
+					 sourceMap: true, // It's required to have sourceMap for resolve-url-loader, resolve-url-loader will keep or drop maps on it's step.
+				 },
+			 },
+		 ];
+	 }
+ }
 
-	let dirs = await glob(
-		[
-			'./packages/mu-plugins/*',
-			'./packages/plugins/*',
-			'./packages/themes/*',
-		],
-		{ onlyDirectories: true }
-	);
+ /**
+  * Collect information about all packages
+  * and their entry files using entry-files.json files.
+  *
+  * @return {Object[]} Array of items with information
+  */
+ function getEntryFiles() {
+	 const entries = [];
 
-	// Only include directories that contains a entry-files.json file.
-	dirs = dirs.filter( ( dir ) =>
-		fs.existsSync( path.resolve( dir, 'entry-files.json' ) )
-	);
+	 // Only include directories that contains a entry-files.json file.
+	 const files = globSync(
+		 './packages/(mu-plugins|plugins|themes)/**/entry-files.json',
+		 { onlyFiles: true }
+	 );
 
-	dirs.forEach( ( dir ) => {
-		const entryFiles = require( `${ dir }/entry-files.json` ); // eslint-disable-line
+	 files.forEach((file) => {
+		 const entryFiles = require( file ); // eslint-disable-line
 
-		entryFiles.forEach( ( entry ) => {
-			/**
-			 * MiniCSSExtractPlugin handles css files. Rename them and ignore in
-			 * IgnoreEmitPlugin to allow as direct entry files.
-			 */
-			entries[
-				`${ dir }|${ entry.replace( '.css', '.css-entry-file' ) }`
-			] = `${ dir }/src/${ entry }`;
-		} );
-	} );
+		 entries.push({
+			 dir: path.dirname(file),
+			 files: entryFiles.map((entryFile) => `src/${entryFile}`),
+		 });
+	 });
 
-	return entries;
-}
+	 return entries;
+ }
 
-/**
- * Config
- */
-const config = {
-	...defaultConfig,
-	entry: async () => getEntries(),
-	output: {
-		path: process.cwd(),
-		filename: ( { chunk } ) => getBuildPath( chunk.name ),
-	},
-	optimization: {
-		...defaultConfig.optimization,
-		splitChunks: {
-			cacheGroups: {
-				style: {
-					type: 'css/mini-extract',
-					test: /[\\/]style(\.module)?\.(sc|sa|c)ss$/,
-					chunks: 'all',
-					enforce: true,
-					name( _, chunks ) {
-						return getBuildPath(
-							chunks[ 0 ].name.replace(
-								'.css-entry-file',
-								'.css'
-							)
-						);
-					},
-				},
-				default: false,
-			},
-		},
-	},
-	resolve: {
-		...defaultConfig.resolve,
-		alias: {
-			...defaultConfig.resolve.alias,
-			components: path.resolve( __dirname, 'packages', 'components' ),
-		},
-	},
-	plugins: [
-		new MiniCSSExtractPlugin( { filename: '[name]' } ),
-		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-		new IgnoreEmitPlugin( /\.css-entry-file$/ ),
-	],
-};
+ /**
+  * Closure function to pretty print information about packages and
+  * their entry files of assets.
+  */
+ const packagesTable = (() => {
+	 const entriesForTable = {};
 
-/**
- * Browsersync
- */
-if ( 'true' === process.env.BROWSER_SYNC_ENABLE ) {
-	config.plugins.push(
-		new BrowserSyncPlugin( {
-			files: '**/*.php',
-			proxy: process.env.BROWSER_SYNC_PROXY ?? process.env.WP_HOME,
-			port: process.env.BROWSER_SYNC_PORT ?? 3002,
-			https: 'true' === process.env.BROWSER_SYNC_HTTPS,
-		} )
-	);
-}
+	 const p = new Table({
+		 columns: [
+			 { name: 'dir', title: 'Package', alignment: 'left' },
+			 { name: 'files', title: 'Entry Files', alignment: 'left' },
+		 ],
+	 });
 
-module.exports = config;
+	 return {
+		 printTable: () => {
+			 const dirs = Object.keys(entriesForTable);
+			 dirs.forEach((dir, i) => {
+				 const entryForTable = entriesForTable[dir];
+				 Object.values(entryForTable).forEach((entryForTableItem, j) => {
+					 p.addRow({
+						 dir: j === 0 ? dir : '',
+						 files: entryForTableItem.join(' + '),
+					 });
+				 });
+
+				 if (dirs.length - 1 > i) {
+					 p.addRow({
+						 dir: '───────────────────────────────────────────────────',
+						 files: '────────────────────────────────',
+					 });
+				 }
+			 });
+
+			 p.printTable();
+		 },
+
+		 logEntry: (dir, file) => {
+			 const fileName = path.parse(file).name;
+
+			 if (typeof entriesForTable[dir] === 'undefined') {
+				 entriesForTable[dir] = [];
+			 }
+
+			 if (typeof entriesForTable[dir][fileName] === 'undefined') {
+				 entriesForTable[dir][fileName] = [];
+			 }
+			 entriesForTable[dir][fileName].push(file);
+		 },
+	 };
+ })();
+
+ /**
+  * Prepares Config for defined package and entry files,
+  *
+  * Future: We can differ configuration between packages or use their own configuration
+  * or implement importing webpack.config.js from their folders.
+  *
+  * @param {string} dir   Package full path.
+  * @param {Array}  files Relative paths of enries.
+  * @return {webpack.Configuration} Return single webpack configuration.
+  */
+ const prepareConfig = (dir, files) => {
+	 const entries = {};
+
+	 files.forEach((file) => {
+		 const filePath = path.resolve(__dirname, dir, file);
+		 const fileName = path.parse(file).name;
+
+		 if (typeof entries[fileName] === 'undefined') {
+			 entries[fileName] = [];
+		 }
+
+		 entries[fileName].push(filePath);
+		 packagesTable.logEntry(dir, file);
+	 });
+
+	 const config = {
+		 ...defaultConfig,
+
+		 name: dir,
+		 entry: entries,
+
+		 /**
+		  * It exclude including to bundle external copy of libraries.
+		  */
+		 externals: {
+			 jquery: 'jQuery',
+		 },
+
+		 output: {
+			 path: path.resolve(__dirname, dir, 'build'),
+			 filename: '[name].js',
+		 },
+		 optimization: {
+			 ...defaultConfig.optimization,
+			 removeEmptyChunks: true,
+
+			 splitChunks: {
+				 cacheGroups: {
+					 internalStyle: {
+						 type: 'css/mini-extract',
+						 test: /[\\/]+?\.(sc|sa|c)ss$/,
+						 chunks: 'all',
+						 enforce: true,
+					 },
+					 default: false,
+				 },
+			 },
+		 },
+
+		 resolve: {
+			 ...defaultConfig.resolve,
+			 alias: {
+				 ...defaultConfig.resolve.alias,
+				 components: path.resolve(__dirname, 'packages', 'components'),
+			 },
+		 },
+
+		 // Hides rarely used information for more compact appearance of console.
+		 stats: {
+			 children: false,
+			 all: false,
+			 entrypoints: true,
+			 warnings: true,
+			 errors: true,
+			 hash: false,
+			 timings: true,
+			 errorDetails: true,
+			 builtAt: true,
+		 },
+
+		 plugins: [
+			 new MiniCSSExtractPlugin({ filename: '[name].css' }),
+
+			 /**
+			  * It removes empty JS files, when we use CSS/SCSS as main entrypoint of asset.
+			  *
+			  * It's possible to remove also `.asset.php` by writing custom version
+			  */
+			 new RemoveEmptyScriptsPlugin(),
+
+			 new DependencyExtractionWebpackPlugin({ injectPolyfill: true }),
+			 new webpack.ProgressPlugin(),
+
+			 true === process.env.BROWSER_SYNC_ENABLE &&
+				 new BrowserSyncPlugin({
+					 files: '**/*.php',
+					 proxy:
+						 process.env.BROWSER_SYNC_PROXY ?? process.env.WP_HOME,
+					 port: process.env.BROWSER_SYNC_PORT ?? 3002,
+					 https: 'true' === process.env.BROWSER_SYNC_HTTPS,
+				 }),
+		 ].filter(Boolean),
+	 };
+
+	 return config;
+ };
+
+ const files = getEntryFiles();
+
+ /**
+  * We can use Multi-Config mode to build packages in 'sandboxed' mode and parallel.
+  *
+  * https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations
+  */
+ module.exports = files.map((item) => prepareConfig(item.dir, item.files));
+
+ packagesTable.printTable();


### PR DESCRIPTION
Prequel:
Webpack puts static files to the wrong folder for SCSS files,

Improvements:

* **Webpack multi-config mode**
* Each package will be built in an independent ‘sandbox’ in single run
* File changing rebuild only part of project(one package), not all.
* Any plugin or loader should work out-of-box without path/URL issues, root path is package dir now(not project dir)
* Ability to customise config for any package in future
* Supports relative path for assets in SCSS file
* Automatically removes 'empty' JS files if CSS used as main entry of file
* Pretty output without useless lines
* Added table to show structure of build