### PR TITLE
Hide webpack size exceed warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,6 +135,9 @@ const prepareConfig = ( dir, files ) => {
 			},
 		},
 
+		// Hides warnings about size, like: 'WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.'
+		performance: { hints: false },
+
 		// Hides rarely used information for more compact appearance of console.
 		stats: {
 			children: false,


### PR DESCRIPTION
Some block has bigger size and we need to use non-universal ways to split them to chunks.
It looks useless in the common cases. 

```

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (250 kB). This can impact web performance.
Entrypoints:
  main (614 kB)
      loader.js
      loader.js.map

```

The second way to hide it, we can increase limit to 1Mb.

```
performance: {
    maxEntrypointSize: 512000,
    maxAssetSize: 512000
 }
```