### PR TITLE
Cleanup debug constants

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -7,10 +7,10 @@
 
 declare( strict_types = 1 );
 
-define( 'SAVEQUERIES', true );
 define( 'WP_DEBUG', true );
-define( 'SCRIPT_DEBUG', true );
 define( 'WP_DEBUG_DISPLAY', true );
+# phpcs:ignore define( 'SCRIPT_DEBUG', true );
+# phpcs:ignore define( 'SAVEQUERIES', true );
 
 if ( defined( 'WP_CLI' ) && WP_CLI && env( 'MYSQLI_DEFAULT_SOCKET' ) ) {
 	ini_set( 'mysqli.default_socket', env( 'MYSQLI_DEFAULT_SOCKET' ) ); // phpcs:ignore

--- a/config/environments/local.php
+++ b/config/environments/local.php
@@ -7,10 +7,11 @@
 
 declare( strict_types = 1 );
 
-define( 'SAVEQUERIES', true );
 define( 'WP_DEBUG', true );
-define( 'SCRIPT_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );
 define( 'WP_DEBUG_DISPLAY', true );
+# phpcs:ignore define( 'SCRIPT_DEBUG', true );
+# phpcs:ignore define( 'SAVEQUERIES', true );
 
 if ( defined( 'WP_CLI' ) && WP_CLI && env( 'MYSQLI_DEFAULT_SOCKET' ) ) {
 	ini_set( 'mysqli.default_socket', env( 'MYSQLI_DEFAULT_SOCKET' ) ); // phpcs:ignore

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -7,8 +7,5 @@
 
 declare( strict_types = 1 );
 
-define( 'WP_DEBUG_DISPLAY', false );
-define( 'SCRIPT_DEBUG', false );
-
 // Disable all file modifications including updates and update notifications.
 define( 'DISALLOW_FILE_MODS', true );


### PR DESCRIPTION
- No need to repeat default values in production. (`SCRIPT_DEBUG` and `WP_DEBUG_DISPLAY` are `false` by default)
- Disable `SCRIPT_DEBUG` and `SAVEQUERIES` by default for local and development. Having these switched on is a big performance impact and not useful in our daily development.

More on WP debugging: https://wordpress.org/support/article/debugging-in-wordpress/