### PR TITLE
Update default branches for github actions

### DIFF
--- a/.github/workflows/lint-js-css.yml
+++ b/.github/workflows/lint-js-css.yml
@@ -2,9 +2,9 @@ name: Lint JS and CSS
 
 on:
     push:
-        branches: [main]
+        branches: [main, stage, develop]
     pull_request:
-        branches: [main]
+        branches: [main, stage, develop]
         paths:
             - '**.css'
             - '**.js'

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -2,9 +2,9 @@ name: PHP CodeSniffer
 
 on:
     push:
-        branches: [main]
+        branches: [main, stage, develop]
     pull_request:
-        branches: [main]
+        branches: [main, stage, develop]
         paths:
             - '**.php'
             - 'composer.lock'


### PR DESCRIPTION
Add default Dekode branches to GitHub actions so actions will work out of the box.
`stage` and `develop`

Context:
When starting a new project from project-base you have to make sure you add stage and develop branches to github actions trigger. Since those branches are used by default in all projects it makes sense to add them here.