### PR TITLE
Remove typo and color options by default

### DIFF
--- a/packages/themes/dekode-theme/theme.json
+++ b/packages/themes/dekode-theme/theme.json
@@ -5,6 +5,21 @@
 		"layout": {
 			"contentSize": "44rem",
 			"wideSize": "75rem"
+		},
+		"color": {
+			"custom": false,
+			"customDuotone": false,
+			"customGradient": false,
+			"defaultGradients": false,
+			"defaultPalette": false,
+			"duotone": [],
+			"gradients": []
+		},
+		"typography": {
+			"dropCap": false,
+			"customFontSize": false,
+			"letterSpacing": false,
+			"lineHeight": false
 		}
 	},
 	"styles": {

--- a/packages/themes/dekode-theme/theme.json
+++ b/packages/themes/dekode-theme/theme.json
@@ -19,7 +19,11 @@
 			"dropCap": false,
 			"customFontSize": false,
 			"letterSpacing": false,
-			"lineHeight": false
+			"lineHeight": false,
+			"fontSizes": [],
+			"fontWeight": false,
+			"fontStyle": false,
+			"textTransform": false
 		}
 	},
 	"styles": {


### PR DESCRIPTION
Help enforce guidelines to only include font and color options when necessary