### PR TITLE
Use require_once

### DIFF
--- a/packages/themes/dekode-theme/functions.php
+++ b/packages/themes/dekode-theme/functions.php
@@ -7,5 +7,5 @@
 
 declare( strict_types=1 );
 
-require __DIR__ . '/inc/assets.php';
-require __DIR__ . '/inc/setup.php';
+require_once __DIR__ . '/inc/assets.php';
+require_once __DIR__ . '/inc/setup.php';


### PR DESCRIPTION
> The require_once expression is identical to [require](https://www.php.net/manual/en/function.require.php) except PHP will check if the file has already been included, and if so, not include (require) it again.