### PR TITLE
Remove default Prettier options

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,11 +1,6 @@
 module.exports = {
 	useTabs: true,
 	tabWidth: 4,
-	printWidth: 80,
 	singleQuote: true,
 	trailingComma: 'all',
-	bracketSpacing: true,
-	bracketSameLine: false,
-	semi: true,
-	arrowParens: 'always',
 };


### PR DESCRIPTION
These values are the same as the [default Prettier options](https://prettier.io/docs/en/options.html), no need to keep them.
```
printWidth: 80
bracketSpacing: true,
bracketSameLine: false,
semi: true,
arrowParens: 'always',
```