### PR TITLE
Use updated Dekode Coding Standards with removed Neutron Standard and latest commits from WPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"wpackagist-plugin/two-factor": "~0.7.3"
 	},
 	"require-dev": {
-		"dekode/coding-standards": "4.0.0",
+		"dekode/coding-standards": "dev-use-wpcs-dev-develope",
 		"dekode/logging": "1.0.0",
 		"ergebnis/composer-normalize": "^2.29"
 	},

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"wpackagist-plugin/two-factor": "~0.7.3"
 	},
 	"require-dev": {
-		"dekode/coding-standards": "dev-use-wpcs-dev-develope",
+		"dekode/coding-standards": "5.0.0",
 		"dekode/logging": "1.0.0",
 		"ergebnis/composer-normalize": "^2.29"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc909d13bb56a0cfcb5c8e851793332c",
+    "content-hash": "63eb7e94bc9a19976d4ebe8f5500d7a2",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -1151,16 +1151,16 @@
         },
         {
             "name": "dekode/coding-standards",
-            "version": "dev-use-wpcs-dev-develope",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DekodeInteraktiv/coding-standards.git",
-                "reference": "6848afe942fa6c2d1717eee16e74ede03acdfa10"
+                "reference": "37ff30974760d5e61509f95d590a090ef2a3630d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DekodeInteraktiv/coding-standards/zipball/6848afe942fa6c2d1717eee16e74ede03acdfa10",
-                "reference": "6848afe942fa6c2d1717eee16e74ede03acdfa10",
+                "url": "https://api.github.com/repos/DekodeInteraktiv/coding-standards/zipball/37ff30974760d5e61509f95d590a090ef2a3630d",
+                "reference": "37ff30974760d5e61509f95d590a090ef2a3630d",
                 "shasum": ""
             },
             "require": {
@@ -1192,9 +1192,9 @@
             ],
             "support": {
                 "issues": "https://github.com/DekodeInteraktiv/coding-standards/issues",
-                "source": "https://github.com/DekodeInteraktiv/coding-standards/tree/use-wpcs-dev-develope"
+                "source": "https://github.com/DekodeInteraktiv/coding-standards/tree/5.0.0"
             },
-            "time": "2022-12-06T08:58:21+00:00"
+            "time": "2022-12-06T09:50:48+00:00"
         },
         {
             "name": "dekode/logging",
@@ -2028,9 +2028,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "dekode/coding-standards": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c974fa19f9e16b7bd040c3437dca8703",
+    "content-hash": "fc909d13bb56a0cfcb5c8e851793332c",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -268,16 +268,16 @@
         },
         {
             "name": "dekodeinteraktiv/dekode-label-environment",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DekodeInteraktiv/dekode-label-environment.git",
-                "reference": "b8e1850e39e5aeb7830b922ab1b7b0738b6419b5"
+                "reference": "d67e4996adede91032bb2625013f37ca7c8c0195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DekodeInteraktiv/dekode-label-environment/zipball/b8e1850e39e5aeb7830b922ab1b7b0738b6419b5",
-                "reference": "b8e1850e39e5aeb7830b922ab1b7b0738b6419b5",
+                "url": "https://api.github.com/repos/DekodeInteraktiv/dekode-label-environment/zipball/d67e4996adede91032bb2625013f37ca7c8c0195",
+                "reference": "d67e4996adede91032bb2625013f37ca7c8c0195",
                 "shasum": ""
             },
             "require-dev": {
@@ -291,9 +291,9 @@
             "description": "Adds a banner to the frontend and an item to the admin bar informing about the server environment",
             "support": {
                 "issues": "https://github.com/DekodeInteraktiv/dekode-label-environment/issues",
-                "source": "https://github.com/DekodeInteraktiv/dekode-label-environment/tree/1.0.1"
+                "source": "https://github.com/DekodeInteraktiv/dekode-label-environment/tree/1.0.2"
             },
-            "time": "2022-12-01T14:14:09+00:00"
+            "time": "2022-12-02T11:32:09+00:00"
         },
         {
             "name": "inpsyde/wp-translation-downloader",
@@ -1075,53 +1075,6 @@
     ],
     "packages-dev": [
         {
-            "name": "automattic/phpcs-neutron-standard",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/phpcs-neutron-standard.git",
-                "reference": "566ad70534296073afa9143858671356444ddead"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/phpcs-neutron-standard/zipball/566ad70534296073afa9143858671356444ddead",
-                "reference": "566ad70534296073afa9143858671356444ddead",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.3.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6 || ^0.7",
-                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-                "sirbrillig/phpcs-variable-analysis": "^2.0.1"
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "NeutronStandard\\": "NeutronStandard/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Payton Swick",
-                    "email": "payton@foolord.com"
-                }
-            ],
-            "description": "A set of phpcs sniffs for modern php development.",
-            "support": {
-                "issues": "https://github.com/sirbrillig/phpcs-neutron-standard/issues",
-                "source": "https://github.com/sirbrillig/phpcs-neutron-standard",
-                "wiki": "https://github.com/sirbrillig/phpcs-neutron-standard/wiki"
-            },
-            "time": "2021-02-15T22:42:03+00:00"
-        },
-        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
             "source": {
@@ -1198,23 +1151,25 @@
         },
         {
             "name": "dekode/coding-standards",
-            "version": "4.0.0",
+            "version": "dev-use-wpcs-dev-develope",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DekodeInteraktiv/coding-standards.git",
-                "reference": "6e8301311d1c71e70104c9fc6553d3e785413070"
+                "reference": "6848afe942fa6c2d1717eee16e74ede03acdfa10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DekodeInteraktiv/coding-standards/zipball/6e8301311d1c71e70104c9fc6553d3e785413070",
-                "reference": "6e8301311d1c71e70104c9fc6553d3e785413070",
+                "url": "https://api.github.com/repos/DekodeInteraktiv/coding-standards/zipball/6848afe942fa6c2d1717eee16e74ede03acdfa10",
+                "reference": "6848afe942fa6c2d1717eee16e74ede03acdfa10",
                 "shasum": ""
             },
             "require": {
-                "automattic/phpcs-neutron-standard": "^1.6",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "wp-coding-standards/wpcs": "^2.3"
+                "phpcompatibility/phpcompatibility-wp": "~2.1.3",
+                "wp-coding-standards/wpcs": "dev-develop"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.29"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1222,11 +1177,24 @@
                 "MIT"
             ],
             "description": "Dekode Coding Standards",
+            "keywords": [
+                "Code style",
+                "Coding Style",
+                "DekodeInteraktiv",
+                "PHP standards",
+                "WordPress standards",
+                "code standards",
+                "coding standards",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
             "support": {
                 "issues": "https://github.com/DekodeInteraktiv/coding-standards/issues",
-                "source": "https://github.com/DekodeInteraktiv/coding-standards/tree/4.0.0"
+                "source": "https://github.com/DekodeInteraktiv/coding-standards/tree/use-wpcs-dev-develope"
             },
-            "time": "2020-10-26T06:30:57+00:00"
+            "time": "2022-12-06T08:58:21+00:00"
         },
         {
             "name": "dekode/logging",
@@ -1819,6 +1787,136 @@
             "time": "2022-10-24T09:00:36+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "a8415f9c2b7360e7184aad803a2c7e2b0544b4f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/a8415f9c2b7360e7184aad803a2c7e2b0544b4f1",
+                "reference": "a8415f9c2b7360e7184aad803a2c7e2b0544b4f1",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0 || dev-develop",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2020-06-29T03:39:34+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.0-alpha4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "37c6da9a0aede973974ae02ef1af2dd641355e86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/37c6da9a0aede973974ae02ef1af2dd641355e86",
+                "reference": "37c6da9a0aede973974ae02ef1af2dd641355e86",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
+                "yoast/phpunit-polyfills": "^1.0.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2022-10-25T13:57:45+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -1876,31 +1974,32 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "eddec932cea5a120b6b279ab31665b77b24d4541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/eddec932cea5a120b6b279ab31665b77b24d4541",
+                "reference": "eddec932cea5a120b6b279ab31665b77b24d4541",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.0",
+                "phpcsstandards/phpcsutils": "^1.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
-            },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1916,6 +2015,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -1923,12 +2023,14 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "time": "2022-12-05T22:26:40+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "dekode/coding-standards": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,11 +3,5 @@
 	<file>.</file>
 	<arg name="extensions" value="php" />
 	<config name="testVersion" value="8.1-" />
-
-	<exclude-pattern>/public/content/themes</exclude-pattern>
-	<exclude-pattern>/public/content/plugins</exclude-pattern>
-	<exclude-pattern>/public/content/mu-plugins</exclude-pattern>
-	<exclude-pattern>/public/content/object-cache.php</exclude-pattern>
-
 	<rule ref="Dekode" />
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,15 +4,10 @@
 	<arg name="extensions" value="php" />
 	<config name="testVersion" value="8.1-" />
 
-	<exclude-pattern>build</exclude-pattern>
-	<exclude-pattern>uploads</exclude-pattern>
 	<exclude-pattern>/public/content/themes</exclude-pattern>
 	<exclude-pattern>/public/content/plugins</exclude-pattern>
 	<exclude-pattern>/public/content/mu-plugins</exclude-pattern>
 	<exclude-pattern>/public/content/object-cache.php</exclude-pattern>
 
-	<rule ref="Dekode">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
-	</rule>
+	<rule ref="Dekode" />
 </ruleset>


### PR DESCRIPTION
Heads up; Dekode Coding Standards 5.0.0 requires `minimum-stability` to be set to `dev` as we're following the `develop` branch from [WPCS](https://github.com/WordPress/WordPress-Coding-Standards).

Correspond with this PR in Coding Standards: https://github.com/DekodeInteraktiv/coding-standards/pull/27

Related thread: https://github.com/WordPress/WordPress-Coding-Standards/issues/2070