### PR TITLE
Remove wp-translation-downloader.lock before downloading translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
 			"@composer install"
 		],
 		"build-for-deploy": [
-			"@composer install --no-dev && composer build-translations",
+			"@composer install --no-dev && composer build-translations"
 		],
 		"build-translations": [
 			"rm -f wp-translation-downloader.lock",

--- a/composer.json
+++ b/composer.json
@@ -111,9 +111,7 @@
 			"@composer install"
 		],
 		"build-for-deploy": [
-			"@composer install --no-dev",
-			"rm -f wp-translation-downloader.lock",
-			"composer wp-translation-downloader:download"
+			"@composer install --no-dev && composer build-translations",
 		],
 		"build-translations": [
 			"rm -f wp-translation-downloader.lock",

--- a/composer.json
+++ b/composer.json
@@ -111,9 +111,12 @@
 			"@composer install"
 		],
 		"build-for-deploy": [
-			"@composer install --no-dev && composer wp-translation-downloader:download"
+			"@composer install --no-dev",
+			"rm -f wp-translation-downloader.lock",
+			"composer wp-translation-downloader:download"
 		],
 		"build-translations": [
+			"rm -f wp-translation-downloader.lock",
 			"@composer wp-translation-downloader:download"
 		],
 		"lint": [


### PR DESCRIPTION
Adds removal of the `wp-translation-downloader.lock` file to the composer scripts `build-for-deploy` and `build-translations` to ensure that any existing translations are being updated.