### PR TITLE
Tooling: Introduce Psalm static code and security scanning.

### DIFF
--- a/.github/workflows/security-psalm.yml
+++ b/.github/workflows/security-psalm.yml
@@ -1,0 +1,28 @@
+name: Psalm Static analysis
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Run every Monday at 1am.
+        - cron: '0 1 * * 1'
+
+jobs:
+    psalm:
+        name: Psalm
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Psalm
+              uses: docker://ghcr.io/psalm/psalm-github-actions
+              env:
+                  COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+              with:
+                  security_analysis: true
+                  report_file: psalm-results.sarif
+
+            - name: Upload Security Analysis results to GitHub
+              uses: github/codeql-action/upload-sarif@v2
+              with:
+                  sarif_file: psalm-results.sarif

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<psalm
+	findUnusedBaselineEntry="true"
+	findUnusedCode="true"
+>
+	<projectFiles>
+		<directory name="." />
+
+		<ignoreFiles>
+			<!-- WordPress core has its own security routines we lean on and trust, so we do not need to scan them. -->
+			<directory name="public/wp" />
+		</ignoreFiles>
+	</projectFiles>
+</psalm>


### PR DESCRIPTION
Introduce automated static cone analysis via Psalm.

Although GitHub offers CodeQL, they do not account for PHP files natively, and instead recommend using third parties.

This PR introduced Psalm, with rules to run a weekly scan (every Monday at 1am), or by manually triggering the workflow, for issues within the codebase. It intentionally will install Composer dependencies, but exclude the `public/wp` directory. This is due to WordPress having its own security team and procedures which we should lean on, given that the results form a basic scan such as this are likely already accounted for, and covered by countless security vendors reporting issues upstream.

Code scanning is configured to add any security alerts to the **Security** tab by default.