### PR TITLE
GitHub Actions: Update action runners.

### DIFF
--- a/.github/workflows/checkout-and-build.yml
+++ b/.github/workflows/checkout-and-build.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Get Composer cache directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Set up Composer caching
               uses: actions/cache@v3

--- a/.github/workflows/checkout-and-build.yml
+++ b/.github/workflows/checkout-and-build.yml
@@ -39,7 +39,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Set up Composer caching
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               env:
                   cache-name: cache-composer-dependencies
               with:

--- a/.github/workflows/deploy-manual-production.yml
+++ b/.github/workflows/deploy-manual-production.yml
@@ -5,7 +5,7 @@ on:
         inputs:
             TAG:
                 description: 'Version to deploy, can be a tag, branch, commit or empty for latest'
-                required: true
+                required: false
                 type: string
                 default: ''
             PHP_VERSION:

--- a/.github/workflows/deploy-manual-production.yml
+++ b/.github/workflows/deploy-manual-production.yml
@@ -41,3 +41,15 @@ jobs:
             DEPLOYMENT_PATH: ${{ secrets.PROD_DEPLOYMENT_PATH }}
             SERVER_PRIVATE_KEY: ${{ secrets.ACTIONS_DEPLOYMENT_KEY_ED25519_BASE64 }}
             SERVER_HOSTKEY: ${{ secrets.PROD_DEPLOYMENT_HOSTKEY }}
+
+    cleanup:
+        runs-on: ubuntu-latest
+        needs: [ deploy ]
+
+        steps:
+            # Delete artifacts after use.
+            - uses: geekyeggo/delete-artifact@v2
+              with:
+                  failOnError: false
+                  name: 'compressed-code-artifact'
+                  useGlob: false

--- a/.github/workflows/deploy-manual-stage.yml
+++ b/.github/workflows/deploy-manual-stage.yml
@@ -41,3 +41,15 @@ jobs:
             DEPLOYMENT_PATH: ${{ secrets.STAGE_DEPLOYMENT_PATH }}
             SERVER_PRIVATE_KEY: ${{ secrets.ACTIONS_DEPLOYMENT_KEY_ED25519_BASE64 }}
             SERVER_HOSTKEY: ${{ secrets.STAGE_DEPLOYMENT_HOSTKEY }}
+
+    cleanup:
+        runs-on: ubuntu-latest
+        needs: [ deploy ]
+
+        steps:
+            # Delete artifacts after use.
+            - uses: geekyeggo/delete-artifact@v2
+              with:
+                  failOnError: false
+                  name: 'compressed-code-artifact'
+                  useGlob: false

--- a/.github/workflows/deploy-manual-stage.yml
+++ b/.github/workflows/deploy-manual-stage.yml
@@ -5,7 +5,7 @@ on:
         inputs:
             TAG:
                 description: 'Version to deploy, can be a tag, branch, commit or empty for latest'
-                required: true
+                required: false
                 type: string
                 default: ''
             PHP_VERSION:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -25,3 +25,15 @@ jobs:
             DEPLOYMENT_PATH: ${{ secrets.PROD_DEPLOYMENT_PATH }}
             SERVER_PRIVATE_KEY: ${{ secrets.ACTIONS_DEPLOYMENT_KEY_ED25519_BASE64 }}
             SERVER_HOSTKEY: ${{ secrets.PROD_DEPLOYMENT_HOSTKEY }}
+
+    cleanup:
+        runs-on: ubuntu-latest
+        needs: [ deploy ]
+
+        steps:
+            # Delete artifacts after use.
+            - uses: geekyeggo/delete-artifact@v2
+              with:
+                  failOnError: false
+                  name: 'compressed-code-artifact'
+                  useGlob: false

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -26,3 +26,15 @@ jobs:
             DEPLOYMENT_PATH: ${{ secrets.STAGE_DEPLOYMENT_PATH }}
             SERVER_PRIVATE_KEY: ${{ secrets.ACTIONS_DEPLOYMENT_KEY_ED25519_BASE64 }}
             SERVER_HOSTKEY: ${{ secrets.STAGE_DEPLOYMENT_HOSTKEY }}
+
+    cleanup:
+        runs-on: ubuntu-latest
+        needs: [ deploy ]
+
+        steps:
+            # Delete artifacts after use.
+            - uses: geekyeggo/delete-artifact@v2
+              with:
+                failOnError: false
+                name: 'compressed-code-artifact'
+                useGlob: false

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: Get Composer cache directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Set up Composer caching
               uses: actions/cache@v3

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -31,7 +31,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Set up Composer caching
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               env:
                   cache-name: cache-composer-dependencies
               with:


### PR DESCRIPTION
This is a collection of enhancements to the GitHub actions related to the deployment workflows;

- Switch to v3 of the cache action to prevent warnings about JS engines.
- Use the new format for saving output from a job step.
- Make the `TAG` attribute optional when making a manual deployment, to grab the latest code by default as intended.
- Add artifact cleanups. Artifacts are reused through a workflow, but are also tied to the workflow, and not needed afterwards.

The introduction of artifact cleanup is to lower our storage space use (in time) on GitHub to just a few minutes, allowing for many more concurrent projects before incurring additional charges.