### PR TITLE
Tooling: Do not automatically run Psalm on every project.

### DIFF
--- a/.github/workflows/security-psalm.yml
+++ b/.github/workflows/security-psalm.yml
@@ -2,9 +2,9 @@ name: Psalm Static analysis
 
 on:
     workflow_dispatch:
-    schedule:
+    #schedule:
         # Run every Monday at 1am.
-        - cron: '0 1 * * 1'
+        #- cron: '0 1 * * 1'
 
 jobs:
     psalm:


### PR DESCRIPTION
The Psalm scanner is useful, but can be quite resource draining. By not having it automatically enabled on projects right away. Instead, this keeps it available in a standarized manner once the project needs are surfaced.