### PR TITLE
Bugfix/Consistently set Workflow Node Version

### DIFF
--- a/.github/workflows/checkout-and-build.yml
+++ b/.github/workflows/checkout-and-build.yml
@@ -76,7 +76,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version-file: '.nvmrc'
                   cache: npm
 
             - name: Install Dependencies


### PR DESCRIPTION
## Short introduction
Use the `.nvmrc` file to set the node version in all workflows so that all our builds are consistent.
