### PR TITLE
Enhance/anonimiziter-multisite

### DIFF
--- a/anonymize.config.json
+++ b/anonymize.config.json
@@ -1,6 +1,39 @@
 {
 	"patterns": [
 		{
+			"tableName": ".*_registration_log",
+			"fields": [
+				{
+					"field": "email",
+					"position": 2,
+					"type": "email",
+					"constraints": null
+				}
+			]
+		},
+		{
+			"tableName": ".*_sitemeta",
+			"fields": [
+				{
+					"field": "admin_email",
+					"position": 4,
+					"type": "email",
+					"constraints": null
+				}
+			]
+		},
+		{
+			"tableName": ".*_options",
+			"fields": [
+				{
+					"field": "admin_email",
+					"position": 3,
+					"type": "email",
+					"constraints": null
+				}
+			]
+		},
+		{
 			"tableName": ".*_users",
 			"fields": [
 				{


### PR DESCRIPTION
Extend config to anonymize multisite elements.
`registration_log` -  anonymize users registration logs
`sitemeta` - anonymize site admin
`options` - anonymize website admin