### PR TITLE
Set required version for T2 Custom Block Margin extension

### DIFF
--- a/packages/themes/dekode-theme/t2.json
+++ b/packages/themes/dekode-theme/t2.json
@@ -10,11 +10,13 @@
 		"t2/custom-block-margin",
 		"t2/disable-block-directory",
 		"t2/disable-custom-css",
-		"t2/disable-floc",
 		"t2/disable-full-site-editing",
 		"t2/disable-xmlrpc",
 		"t2/remove-core-patterns",
 		"t2/reset-admin-dashboard",
 		"t2/site-health-qa"
-	]
+	],
+	"t2/custom-block-margin": {
+		"version": 2
+	}
 }


### PR DESCRIPTION
A version number for T2 Custom Block Margin extension is required in `t2.json` as of T2 6.3.0. Setting to latest version to get rid of the PHP notice.

<img width="1872" alt="Screenshot 2024-05-24 at 09 09 26" src="https://github.com/DekodeInteraktiv/project-base/assets/16900754/0bebe7d8-15c9-41ed-a54b-17d7058e0d95">
