### PR TITLE
Update Anonimizer: Fix admin email, Add signups to anonimize.

### DIFF
--- a/anonymize.config.json
+++ b/anonymize.config.json
@@ -18,7 +18,13 @@
 					"field": "admin_email",
 					"position": 4,
 					"type": "email",
-					"constraints": null
+					"constraints": [
+						{
+							"field": "meta_value",
+							"position": 2,
+							"value": "admin_email"
+						}
+					]
 				}
 			]
 		},
@@ -29,6 +35,35 @@
 					"field": "admin_email",
 					"position": 3,
 					"type": "email",
+					"constraints": [
+						{
+							"field": "option_name",
+							"position": 2,
+							"value": "admin_email"
+						}
+					]
+				}
+			]
+		},
+		{
+			"tableName": ".*_signups",
+			"fields": [
+				{
+					"field": "user_login",
+					"position": 5,
+					"type": "username",
+					"constraints": null
+				},
+				{
+					"field": "user_email",
+					"position": 6,
+					"type": "email",
+					"constraints": null
+				},
+				{
+					"field": "activation_key",
+					"position": 10,
+					"type": "shortString",
 					"constraints": null
 				}
 			]


### PR DESCRIPTION
Hi,

The PR contains 2 bug fixes (thanks to @PeterBooker) and extra config for multisite signups.

### Extra feature:

Simply added anonymization for WordPress Multisite `*_signups` table.
I'd suggest to add dates to anonymization in future, but at this point we don't have correct config for faker(https://github.com/DekodeInteraktiv/anonymize-mysqldump/issues/30)

### Bug fixes:

Tables `options` and `sitemeta` were missing `constraints` setup, which results with whole column being incorrectly replaced with emails :D 
Thanks @PeterBooker for pointing this out 🥇 

### Tests

I have tested it locally on RoomSketcher Database - seems to be working as intended in both cases - bug fixes and new feature.
