### PR TITLE
Add Turborepo to build and watch packages in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ sql/
 # Other
 debug.log
 wp-debug.log
+.turbo

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"postcss-url": "^10.1.3",
 				"prettier": "^3.3.2",
 				"resolve-url-loader": "^5.0.0",
+				"turbo": "^2.0.5",
 				"webpack-remove-empty-scripts": "^1.0.4"
 			},
 			"engines": {
@@ -22131,6 +22132,101 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
+		"node_modules/turbo": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.5.tgz",
+			"integrity": "sha512-+6+hcWr4nwuESlKqUc626HMOTd3QT8hUOc9QM45PP1d4nErGkNOgExm4Pcov3in7LTuadMnB0gcd/BuzkEDIPw==",
+			"dev": true,
+			"bin": {
+				"turbo": "bin/turbo"
+			},
+			"optionalDependencies": {
+				"turbo-darwin-64": "2.0.5",
+				"turbo-darwin-arm64": "2.0.5",
+				"turbo-linux-64": "2.0.5",
+				"turbo-linux-arm64": "2.0.5",
+				"turbo-windows-64": "2.0.5",
+				"turbo-windows-arm64": "2.0.5"
+			}
+		},
+		"node_modules/turbo-darwin-64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.5.tgz",
+			"integrity": "sha512-t/9XpWYIjOhIHUdwiR47SYBGYHkR1zWLxTkTNKZwCSn8BN0cfjPZ1BR6kcwYGxLGBhtl5GBf6A29nq2K7iwAjg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/turbo-darwin-arm64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.5.tgz",
+			"integrity": "sha512-//5y4RJvnal8CttOLBwlaBqblcQb1qTlIxLN+I8O3E3rPuvHOupNKB9ZJxYIQ8oWf8ns8Ec8cxQ0GSBLTJIMtA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/turbo-linux-64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.5.tgz",
+			"integrity": "sha512-LDtEDU2Gm8p3lKu//aHXZFRKUCVu68BNF9LQ+HmiCKFpNyK7khpMTxIAAUhDqt+AzlrbxtrxcCpCJaWg1JDjHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/turbo-linux-arm64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.5.tgz",
+			"integrity": "sha512-84wdrzntErBNxkHcwHxiTZdaginQAxGPnwLTyZj8lpUYI7okPoxy3jKpUeMHN3adm3iDedl/x0mYSIvVVkmOiA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/turbo-windows-64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.5.tgz",
+			"integrity": "sha512-SgaFZ0VW6kHCJogLNuLEleAauAJx2Y48wazZGVRmBpgSUS2AylXesaBMhJaEScYqLz7mIRn6KOgwM8D4wTxI9g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/turbo-windows-arm64": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.5.tgz",
+			"integrity": "sha512-foUxLOZoru0IRNIxm53fkfM4ubas9P0nTFjIcHtd+E8YHeogt8GqTweNre2e6ri1EHDo71emmuQgpuoFCOXZMg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -23499,6 +23595,7 @@
 			}
 		},
 		"packages/plugins/blueprint": {
+			"name": "@dekode/blueprint",
 			"version": "1.0.0",
 			"devDependencies": {
 				"@wordpress/dom-ready": "^4.1.0",
@@ -23506,6 +23603,7 @@
 			}
 		},
 		"packages/themes/dekode-theme": {
+			"name": "@dekode/dekode-theme",
 			"version": "1.0.0",
 			"devDependencies": {
 				"@theme-json/create": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"npm": ">=8",
 		"yarn": "Please use npm"
 	},
+	"packageManager": "npm@10.7.0",
 	"workspaces": [
 		"packages/mu-plugins/*",
 		"packages/plugins/*",
@@ -34,15 +35,16 @@
 		"postcss-url": "^10.1.3",
 		"prettier": "^3.3.2",
 		"resolve-url-loader": "^5.0.0",
+		"turbo": "^2.0.5",
 		"webpack-remove-empty-scripts": "^1.0.4"
 	},
 	"scripts": {
 		"create-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block",
 		"create-innerblock-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block --template innerblocks",
 		"prepare": "husky",
-		"build": "npm run build --workspaces --if-present",
-		"start": "npm run start --workspaces --if-present",
-		"clean": "npm run clean --workspaces --if-present && rm -rf node_modules",
+		"build": "turbo run build",
+		"start": "turbo run start",
+		"clean": "turbo run clean && rm -rf node_modules",
 		"format": "prettier --write .",
 		"check-engines": "wp-scripts check-engines",
 		"lint": "npm run lint:js && npm run lint:css && npm run lint:format",

--- a/packages/plugins/blueprint/package.json
+++ b/packages/plugins/blueprint/package.json
@@ -8,6 +8,6 @@
 	"scripts": {
 		"build": "wp-scripts build --webpack-copy-php",
 		"start": "wp-scripts start --webpack-copy-php",
-		"clean": "rm -rf node_modules build dist"
+		"clean": "rm -rf node_modules build dist .turbo"
 	}
 }

--- a/packages/themes/dekode-theme/package.json
+++ b/packages/themes/dekode-theme/package.json
@@ -15,7 +15,7 @@
 		"start": "concurrently npm:start:*",
 		"start:wp-scripts": "wp-scripts start",
 		"_start:theme-json": "theme-json watch",
-		"clean": "rm -rf node_modules build dist"
+		"clean": "rm -rf node_modules build dist .turbo"
 	},
 	"css-clamp": {
 		"minWidth": 512,

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"tasks": {
+		"build": {
+			"dependsOn": ["^build"]
+		},
+		"start": {
+			"cache": false,
+			"persistent": true
+		},
+		"clean": {
+			"cache": false
+		}
+	}
+}


### PR DESCRIPTION
NPM workspaces does not support watching `wp-scripts start` in multiple packages at once. I suggest we introduce [Turbo build](https://turbo.build/repo/docs) to build and watch packages in parallel. 

Read more about Turbo repo here: https://turbo.build/repo/docs