### PR TITLE
Fix editor title style for iframed post editor

### DIFF
--- a/packages/plugins/blueprint/src/block.json
+++ b/packages/plugins/blueprint/src/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"editorScript": "file:editor.js",
 	"viewScript": "file:view.js"
 }

--- a/packages/plugins/blueprint/src/example-block/block.json
+++ b/packages/plugins/blueprint/src/example-block/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "dekode/example-block",
 	"title": "Example Block",
 	"category": "widgets",

--- a/packages/themes/block-theme/src/block.json
+++ b/packages/themes/block-theme/src/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"editorScript": "file:editor.js",
 	"viewScript": "file:view.js"
 }

--- a/packages/themes/block-theme/src/editor.css
+++ b/packages/themes/block-theme/src/editor.css
@@ -3,7 +3,9 @@ Less prominent editor post title for clean singular template.
 Remove this if you're using a singular.html template with hard coded title block.
 */
 .post-type-page .editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper,
-.post-type-post .editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper {
+.post-type-post .editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper,
+.post-type-page.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper,
+.post-type-post.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper {
 	background-color: transparent;
 	border-bottom: 1px solid #e0e0e0;
 	color: inherit;

--- a/packages/themes/dekode-theme/src/block.json
+++ b/packages/themes/dekode-theme/src/block.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"viewScript": "file:view.js"
 }


### PR DESCRIPTION
If the editor is iframed (when matching all [requirements](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/)) the CSS selector for targeting the post title is slightly different.

This PR adds support for both old and new selector and set api version to 3 for all project blocks.