### PR TITLE
Remove image caption fix for WP before 6.6

### DIFF
--- a/packages/themes/block-theme/src/blocks/core/image.css
+++ b/packages/themes/block-theme/src/blocks/core/image.css
@@ -9,12 +9,3 @@
 .wp-block-post-featured-image img {
 	display: block;
 }
-
-/* Reset styling for figcaption (Image block overrides caption styling from theme.json) */
-.wp-block-image figcaption {
-	color: unset;
-	font-size: var(--wp--preset--font-size--small);
-	line-height: unset;
-	margin: unset;
-	text-align: unset;
-}

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -171,6 +171,12 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "unset"
+				},
+				"spacing": {
+					"margin": {
+						"top": "0",
+						"bottom": "0"
+					}
 				}
 			}
 		},


### PR DESCRIPTION
The override css for Image block figcaption is no longer needed in WP 6.6. Caption from `theme.json` takes precedence also for the Image block.