### PR TITLE
Update anonymize.config.json with a declarative "I've modified this file" entry

### DIFF
--- a/anonymize.config.json
+++ b/anonymize.config.json
@@ -1,4 +1,5 @@
 {
+	"__RemoveAfterSetup__": "This line exists to ensure anonymization configs are checked when a new project is set up, and should be removed once the contents of the config file have been validated against the contents expected on a site.",
 	"patterns": [
 		{
 			"tableName": ".*_registration_log",


### PR DESCRIPTION
The anonymizer config is an important tool in staying compliant with privacy regulations in relation to development work, and as such it is important to _never_ trust the default.

Of course, this is hard when there's a rather reliable default provided, and it is easy to become complacent and just expect the best.

This PR introduce a initial "comment" entry to the anonymizer config file, which has the intent to "declare" that a config has been validated for a given project setup.

By introducing this line, it is also possible to say "the default is OK", and without making modifications to the configs them selves, and still allow for automation in detecting projects where this has been missed.