### PR TITLE
Disable unused T2 blocks and extensions by default

### DIFF
--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -13,9 +13,7 @@
 		"t2/footer",
 		"t2/header-horizontal",
 		"t2/ingress",
-		"t2/link-list",
-		"t2/nav-menu",
-		"t2/state-toggle"
+		"t2/link-list"
 	],
 	"mu-extensions": [
 		"t2/allow-svg-uploads",
@@ -30,7 +28,6 @@
 		"t2/enqueue-theme-block-styles",
 		"t2/image-credit",
 		"t2/imagify-helper",
-		"t2/list-block-classname",
 		"t2/post-content-tag-name",
 		"t2/remove-core-block-styles",
 		"t2/remove-core-patterns",


### PR DESCRIPTION
- Remove `t2/nav-menu` and `t2/state-toggle`. These blocks are not in use in the default Project Base setup yet.
- Remove deprecated extensions `t2/list-block-classname`. [Read more](https://github.com/DekodeInteraktiv/T2/pull/4630).