### PR TITLE
Build POT files for plugins and themes from project root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2219,10 +2219,6 @@
 			"resolved": "packages/themes/block-theme",
 			"link": true
 		},
-		"node_modules/@dekode/blueprint": {
-			"resolved": "packages/plugins/blueprint",
-			"link": true
-		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -5086,20 +5082,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
-			}
-		},
-		"node_modules/@wordpress/dom-ready": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.8.0.tgz",
-			"integrity": "sha512-HgjykkaC+yLHWnhBkQEua2dbeB8ckF7ht2S4WJELjVo52FXdbDIfw3ht3N4AlN92r6uUaYm/1X1MTVa+DkLasg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
@@ -25442,6 +25424,7 @@
 		"packages/plugins/blueprint": {
 			"name": "@dekode/blueprint",
 			"version": "1.0.0",
+			"extraneous": true,
 			"devDependencies": {
 				"@wordpress/dom-ready": "^4.8.0",
 				"@wordpress/scripts": "^30.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2219,6 +2219,10 @@
 			"resolved": "packages/themes/block-theme",
 			"link": true
 		},
+		"node_modules/@dekode/blueprint": {
+			"resolved": "packages/plugins/blueprint",
+			"link": true
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -5082,6 +5086,20 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/@wordpress/dom-ready": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.8.0.tgz",
+			"integrity": "sha512-HgjykkaC+yLHWnhBkQEua2dbeB8ckF7ht2S4WJELjVo52FXdbDIfw3ht3N4AlN92r6uUaYm/1X1MTVa+DkLasg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
@@ -25424,7 +25442,6 @@
 		"packages/plugins/blueprint": {
 			"name": "@dekode/blueprint",
 			"version": "1.0.0",
-			"extraneous": true,
 			"devDependencies": {
 				"@wordpress/dom-ready": "^4.8.0",
 				"@wordpress/scripts": "^30.0.2"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"start": "turbo run start",
 		"clean": "turbo run clean && rm -rf node_modules",
 		"format": "prettier --write .",
+		"i18n:make-pot": "turbo run i18n:make-pot",
 		"lint": "npm-run-all --parallel lint:js lint:css lint:format",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",

--- a/packages/themes/block-theme/composer.json
+++ b/packages/themes/block-theme/composer.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"make-pot": [
 			"npm run build",
-			"wp i18n make-pot . languages/block-theme.pot --domain=block-theme --exclude=node_modules,src,vendor,theme.json,t2.json"
+			"wp i18n make-pot . languages/block-theme.pot --exclude=.turbo,node_modules,src,vendor,theme.json,t2.json"
 		],
 		"make-json": [
 			"npm run build",

--- a/packages/themes/block-theme/composer.json
+++ b/packages/themes/block-theme/composer.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"make-pot": [
 			"npm run build",
-			"wp i18n make-pot . languages/block-theme.pot --exclude=.turbo,node_modules,src,vendor,theme.json,t2.json"
+			"wp i18n make-pot . --exclude=.turbo,node_modules,src,vendor,theme.json,t2.json"
 		],
 		"make-json": [
 			"npm run build",

--- a/packages/themes/block-theme/package.json
+++ b/packages/themes/block-theme/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"build": "wp-scripts build --webpack-copy-php",
 		"start": "wp-scripts start --webpack-copy-php",
-		"clean": "rm -rf node_modules build dist .turbo"
+		"clean": "rm -rf node_modules build dist .turbo",
+		"i18n:make-pot": "composer run make-pot"
 	}
 }

--- a/packages/themes/block-theme/style.css
+++ b/packages/themes/block-theme/style.css
@@ -6,6 +6,7 @@
  * License: GNU General Public License v2 or later
  * License URI: LICENSE
  * Text Domain: block-theme
+ * Domain Path: languages
  * Tags: editor-style, featured-images, full-site-editing, block-patterns
  *
  * This theme, like WordPress, is licensed under the GPL.

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,9 @@
 		},
 		"clean": {
 			"cache": false
+		},
+		"i18n:make-pot": {
+			"dependsOn": ["^i18n:make-pot"]
 		}
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
 			"cache": false
 		},
 		"i18n:make-pot": {
-			"dependsOn": ["^i18n:make-pot"]
+			"dependsOn": ["^i18n:make-pot"],
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
## Short introduction
This introduces a NPM, and subsequent Turbo command for running `i18n:make-pot` across all plugins and themes in a project, to allow individual translation files to be prepared quickly, efficiently, and hopefully reliably!

## Description
This introduces a new `i18n:make-pot` command to the `package.json`, and `composer.json` files within the project, which Turbo can run to generate POT files, the base file used for translations.

It also modifies the existing `composer run make-pot` command to take the text domain and domain path (language folder) as a base to avoid the need for manually declaring paths, and allowing the commands to be copied easily between plugins and themes.

## Steps to test / reproduce
- `npm run i18n:make-pot`
- Watch as `packages/block-theme`languages`block-theme.pot` is generated
- Validate that it contains the translatable strings.