### PR TITLE
Eslint: Allow importing from @t2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
 	env: {
 		browser: true,
 	},
+	settings: {
+		'import/core-modules': ['@t2/editor'],
+	},
 	rules: {
 		'jsdoc/require-param': 'off',
 		'@wordpress/no-global-event-listener': 'off',


### PR DESCRIPTION
Fix eslint issue with importing `@t2` modules.

<img width="873" alt="Screenshot 2025-01-10 at 08 37 09" src="https://github.com/user-attachments/assets/3a2c17e1-99a5-4e44-86b0-e0311f358126" />
