### PR TITLE
Upgrade to T2 8.3.0 with minor block adjustments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"roots/bedrock-autoloader": "~1.0.4",
 		"roots/wordpress": "~6.7.2",
 		"symfony/dotenv": "~7.2.0",
-		"t2/t2": "~8.2.0",
+		"t2/t2": "~8.3.0",
 		"wpackagist-plugin/imagify": "~2.2.0",
 		"wpackagist-plugin/spinupwp": "~1.7.1",
 		"wpackagist-plugin/two-factor": "~0.12.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7349c3feead0a7ba761006a574387af7",
+    "content-hash": "d08f068a859c33904c898d374d857ca8",
     "packages": [
         {
             "name": "composer/installers",
@@ -602,15 +602,15 @@
         },
         {
             "name": "t2/admin",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-admin-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-admin-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.2.0",
-                "t2/icons": "8.2.0"
+                "t2/config": "8.3.0",
+                "t2/icons": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -631,10 +631,10 @@
         },
         {
             "name": "t2/assets",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-assets-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-assets-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -658,17 +658,17 @@
         },
         {
             "name": "t2/block-library",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-block-library-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-block-library-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/blocks": "8.2.0",
-                "t2/config": "8.2.0",
-                "t2/icons": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/blocks": "8.3.0",
+                "t2/config": "8.3.0",
+                "t2/icons": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -689,16 +689,16 @@
         },
         {
             "name": "t2/blocks",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-blocks-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-blocks-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.2.0",
-                "t2/registry": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/config": "8.3.0",
+                "t2/registry": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -720,10 +720,10 @@
         },
         {
             "name": "t2/components",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-components-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-components-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -747,10 +747,10 @@
         },
         {
             "name": "t2/config",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-config-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-config-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -774,16 +774,16 @@
         },
         {
             "name": "t2/editor",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-editor-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-editor-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.2.0",
-                "t2/icons": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/config": "8.3.0",
+                "t2/icons": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -804,17 +804,17 @@
         },
         {
             "name": "t2/extension-library",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.2.0",
-                "t2/extensions": "8.2.0",
-                "t2/icons": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/config": "8.3.0",
+                "t2/extensions": "8.3.0",
+                "t2/icons": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -835,16 +835,16 @@
         },
         {
             "name": "t2/extensions",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extensions-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extensions-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.2.0",
-                "t2/registry": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/config": "8.3.0",
+                "t2/registry": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -865,14 +865,14 @@
         },
         {
             "name": "t2/icons",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-icons-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-icons-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/utils": "8.2.0"
+                "t2/utils": "8.3.0"
             },
             "type": "package",
             "autoload": {
@@ -893,10 +893,10 @@
         },
         {
             "name": "t2/registry",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-registry-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-registry-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -921,24 +921,24 @@
         },
         {
             "name": "t2/t2",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-t2-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-t2-8.3.0.zip"
             },
             "require": {
-                "t2/admin": "8.2.0",
-                "t2/assets": "8.2.0",
-                "t2/block-library": "8.2.0",
-                "t2/blocks": "8.2.0",
-                "t2/components": "8.2.0",
-                "t2/config": "8.2.0",
-                "t2/editor": "8.2.0",
-                "t2/extension-library": "8.2.0",
-                "t2/extensions": "8.2.0",
-                "t2/icons": "8.2.0",
-                "t2/registry": "8.2.0",
-                "t2/utils": "8.2.0"
+                "t2/admin": "8.3.0",
+                "t2/assets": "8.3.0",
+                "t2/block-library": "8.3.0",
+                "t2/blocks": "8.3.0",
+                "t2/components": "8.3.0",
+                "t2/config": "8.3.0",
+                "t2/editor": "8.3.0",
+                "t2/extension-library": "8.3.0",
+                "t2/extensions": "8.3.0",
+                "t2/icons": "8.3.0",
+                "t2/registry": "8.3.0",
+                "t2/utils": "8.3.0"
             },
             "type": "wordpress-plugin",
             "license": [
@@ -954,14 +954,14 @@
         },
         {
             "name": "t2/utils",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-utils-8.2.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-utils-8.3.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/registry": "8.2.0"
+                "t2/registry": "8.3.0"
             },
             "type": "package",
             "autoload": {

--- a/packages/themes/block-theme/src/blocks/core/image.css
+++ b/packages/themes/block-theme/src/blocks/core/image.css
@@ -2,7 +2,7 @@
 .wp-block-post-featured-image {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wp--preset--spacing--20);
+	gap: var(--wp--custom--t-2--caption--gap, var(--wp--preset--spacing--30));
 }
 
 .wp-block-image img,

--- a/packages/themes/block-theme/src/blocks/t2/accordion.css
+++ b/packages/themes/block-theme/src/blocks/t2/accordion.css
@@ -5,13 +5,3 @@ body {
 	--t2-accordion-typography-heading-line-height: var(--wp--custom--line-height--12);
 	--t2-accordion-item-padding: var(--wp--preset--spacing--40);
 }
-
-.t2-accordion {
-	display: flex;
-	flex-direction: column;
-	gap: var(--wp--preset--spacing--50);
-}
-
-.t2-accordion-item {
-	margin: unset;
-}


### PR DESCRIPTION
- Accordion is now flex layout in T2.
- Using `--wp--custom--t-2--caption--gap` introduced in T2 8.3.0 for gap between media and caption.