### PR TITLE
Remove deprecated no-suggest Composer option

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -56,7 +56,7 @@ jobs:
               env:
                   COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
               run: |
-                  composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+                  composer install --prefer-dist --no-progress --no-ansi --no-interaction
                   echo "vendor/bin" >> $GITHUB_PATH
 
             - name: Log PHPCS debug information


### PR DESCRIPTION
Remove deprecated `--no-suggest` Composer paramenter.

<img width="821" alt="Screenshot 2025-03-20 at 07 51 28" src="https://github.com/user-attachments/assets/c498d8f0-7f68-4c6a-a344-0800cadd246d" />

More info: https://php.watch/articles/composer-2#no--no-suggest
