### PR TITLE
Fix missing folder issue for bedrock autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
 	"scripts": {
 		"post-install-cmd": [
 			"cp public/content/plugins/spinupwp/drop-ins/object-cache.php public/content/object-cache.php",
+			"mkdir -p public/content/mu-plugins",
 			"cp tools/autoloader/bedrock-autoloader.php public/content/mu-plugins/bedrock-autoloader.php",
 			"mkdir -p public/content/languages && cp -r packages/translations/* public/content/languages/",
 			"rm -rf public/wp/wp-content"


### PR DESCRIPTION
Make sure `public/content/mu-plugins` exists before trying to copy `bedrock-autoloader.php` into it.

<img width="1446" alt="Screenshot 2025-03-20 at 07 56 37" src="https://github.com/user-attachments/assets/20bd688e-9959-404d-8b86-b28723581bcf" />
