### PR TITLE
Upgrade to T2 8.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"roots/bedrock-autoloader": "~1.0.4",
 		"roots/wordpress": "~6.7.2",
 		"symfony/dotenv": "~7.2.0",
-		"t2/t2": "~8.7.0",
+		"t2/t2": "~8.8.0",
 		"wpackagist-plugin/imagify": "~2.2.0",
 		"wpackagist-plugin/spinupwp": "~1.7.1",
 		"wpackagist-plugin/two-factor": "~0.12.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69fc8cbc826b57bae13b658a40a324ac",
+    "content-hash": "cfe2bb1488fcb7a05d217c43a7cc26df",
     "packages": [
         {
             "name": "composer/installers",
@@ -573,15 +573,15 @@
         },
         {
             "name": "t2/admin",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-admin-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-admin-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.7.0",
-                "t2/icons": "8.7.0"
+                "t2/config": "8.8.0",
+                "t2/icons": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -602,10 +602,10 @@
         },
         {
             "name": "t2/assets",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-assets-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-assets-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -629,17 +629,17 @@
         },
         {
             "name": "t2/block-library",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-block-library-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-block-library-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/blocks": "8.7.0",
-                "t2/config": "8.7.0",
-                "t2/icons": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/blocks": "8.8.0",
+                "t2/config": "8.8.0",
+                "t2/icons": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -660,16 +660,16 @@
         },
         {
             "name": "t2/blocks",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-blocks-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-blocks-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.7.0",
-                "t2/registry": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/config": "8.8.0",
+                "t2/registry": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -691,10 +691,10 @@
         },
         {
             "name": "t2/config",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-config-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-config-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -718,16 +718,16 @@
         },
         {
             "name": "t2/editor",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-editor-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-editor-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.7.0",
-                "t2/icons": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/config": "8.8.0",
+                "t2/icons": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -748,17 +748,17 @@
         },
         {
             "name": "t2/extension-library",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.7.0",
-                "t2/extensions": "8.7.0",
-                "t2/icons": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/config": "8.8.0",
+                "t2/extensions": "8.8.0",
+                "t2/icons": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -779,16 +779,16 @@
         },
         {
             "name": "t2/extensions",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extensions-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extensions-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.7.0",
-                "t2/registry": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/config": "8.8.0",
+                "t2/registry": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -809,14 +809,14 @@
         },
         {
             "name": "t2/icons",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-icons-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-icons-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/utils": "8.7.0"
+                "t2/utils": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -837,10 +837,10 @@
         },
         {
             "name": "t2/registry",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-registry-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-registry-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -865,23 +865,23 @@
         },
         {
             "name": "t2/t2",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-t2-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-t2-8.8.0.zip"
             },
             "require": {
-                "t2/admin": "8.7.0",
-                "t2/assets": "8.7.0",
-                "t2/block-library": "8.7.0",
-                "t2/blocks": "8.7.0",
-                "t2/config": "8.7.0",
-                "t2/editor": "8.7.0",
-                "t2/extension-library": "8.7.0",
-                "t2/extensions": "8.7.0",
-                "t2/icons": "8.7.0",
-                "t2/registry": "8.7.0",
-                "t2/utils": "8.7.0"
+                "t2/admin": "8.8.0",
+                "t2/assets": "8.8.0",
+                "t2/block-library": "8.8.0",
+                "t2/blocks": "8.8.0",
+                "t2/config": "8.8.0",
+                "t2/editor": "8.8.0",
+                "t2/extension-library": "8.8.0",
+                "t2/extensions": "8.8.0",
+                "t2/icons": "8.8.0",
+                "t2/registry": "8.8.0",
+                "t2/utils": "8.8.0"
             },
             "type": "wordpress-plugin",
             "license": [
@@ -897,14 +897,14 @@
         },
         {
             "name": "t2/utils",
-            "version": "8.7.0",
+            "version": "8.8.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-utils-8.7.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-utils-8.8.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/registry": "8.7.0"
+                "t2/registry": "8.8.0"
             },
             "type": "package",
             "autoload": {
@@ -1484,16 +1484,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.3",
+            "version": "3.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
+                "reference": "ea16a1f3719783345febd3aab41beb55c8c84bfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ea16a1f3719783345febd3aab41beb55c8c84bfd",
+                "reference": "ea16a1f3719783345febd3aab41beb55c8c84bfd",
                 "shasum": ""
             },
             "require": {
@@ -1560,11 +1560,11 @@
                     "type": "open_collective"
                 },
                 {
-                    "url": "https://thanks.dev/phpcsstandards",
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-23T17:04:15+00:00"
+            "time": "2025-04-04T12:57:55+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -573,15 +573,15 @@
         },
         {
             "name": "t2/admin",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-admin-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-admin-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.0",
-                "t2/icons": "8.8.0"
+                "t2/config": "8.8.1",
+                "t2/icons": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -602,10 +602,10 @@
         },
         {
             "name": "t2/assets",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-assets-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-assets-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -629,17 +629,17 @@
         },
         {
             "name": "t2/block-library",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-block-library-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-block-library-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/blocks": "8.8.0",
-                "t2/config": "8.8.0",
-                "t2/icons": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/blocks": "8.8.1",
+                "t2/config": "8.8.1",
+                "t2/icons": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -660,16 +660,16 @@
         },
         {
             "name": "t2/blocks",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-blocks-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-blocks-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.0",
-                "t2/registry": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/config": "8.8.1",
+                "t2/registry": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -691,10 +691,10 @@
         },
         {
             "name": "t2/config",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-config-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-config-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -718,16 +718,16 @@
         },
         {
             "name": "t2/editor",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-editor-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-editor-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.0",
-                "t2/icons": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/config": "8.8.1",
+                "t2/icons": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -748,17 +748,17 @@
         },
         {
             "name": "t2/extension-library",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.0",
-                "t2/extensions": "8.8.0",
-                "t2/icons": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/config": "8.8.1",
+                "t2/extensions": "8.8.1",
+                "t2/icons": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -779,16 +779,16 @@
         },
         {
             "name": "t2/extensions",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extensions-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extensions-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.0",
-                "t2/registry": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/config": "8.8.1",
+                "t2/registry": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -809,14 +809,14 @@
         },
         {
             "name": "t2/icons",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-icons-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-icons-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/utils": "8.8.0"
+                "t2/utils": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -837,10 +837,10 @@
         },
         {
             "name": "t2/registry",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-registry-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-registry-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -865,23 +865,23 @@
         },
         {
             "name": "t2/t2",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-t2-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-t2-8.8.1.zip"
             },
             "require": {
-                "t2/admin": "8.8.0",
-                "t2/assets": "8.8.0",
-                "t2/block-library": "8.8.0",
-                "t2/blocks": "8.8.0",
-                "t2/config": "8.8.0",
-                "t2/editor": "8.8.0",
-                "t2/extension-library": "8.8.0",
-                "t2/extensions": "8.8.0",
-                "t2/icons": "8.8.0",
-                "t2/registry": "8.8.0",
-                "t2/utils": "8.8.0"
+                "t2/admin": "8.8.1",
+                "t2/assets": "8.8.1",
+                "t2/block-library": "8.8.1",
+                "t2/blocks": "8.8.1",
+                "t2/config": "8.8.1",
+                "t2/editor": "8.8.1",
+                "t2/extension-library": "8.8.1",
+                "t2/extensions": "8.8.1",
+                "t2/icons": "8.8.1",
+                "t2/registry": "8.8.1",
+                "t2/utils": "8.8.1"
             },
             "type": "wordpress-plugin",
             "license": [
@@ -897,14 +897,14 @@
         },
         {
             "name": "t2/utils",
-            "version": "8.8.0",
+            "version": "8.8.1",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-utils-8.8.0.zip"
+                "url": "https://t2-packages.teft.io/build/t2-utils-8.8.1.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/registry": "8.8.0"
+                "t2/registry": "8.8.1"
             },
             "type": "package",
             "autoload": {
@@ -1484,16 +1484,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.1",
+            "version": "3.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ea16a1f3719783345febd3aab41beb55c8c84bfd"
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ea16a1f3719783345febd3aab41beb55c8c84bfd",
-                "reference": "ea16a1f3719783345febd3aab41beb55c8c84bfd",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
                 "shasum": ""
             },
             "require": {
@@ -1564,7 +1564,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-04T12:57:55+00:00"
+            "time": "2025-04-13T04:10:18+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"clean": "turbo run clean && rm -rf node_modules",
 		"format": "prettier --write .",
 		"i18n:make-pot": "turbo run i18n:make-pot",
-		"lint": "npm-run-all --parallel lint:js lint:css lint:format",
+		"lint": "npm-run-all --parallel lint:*",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"lint:format": "prettier --check .",

--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -36,7 +36,8 @@
 		"t2/reset-admin-dashboard",
 		"t2/search-block-button-icon",
 		"t2/site-health-qa",
-		"t2/wrap-custom-html-block"
+		"t2/wrap-custom-html-block",
+		"t2/yoast-accessibility"
 	],
 	"t2/custom-block-margin": {
 		"version": 3

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-/* const postcssGlobalData = require('@csstools/postcss-global-data'); */
+const path = require('path');
+const postcssGlobalData = require('@csstools/postcss-global-data');
 const postcssImport = require('postcss-import');
 const postcssMixins = require('postcss-mixins');
 const postcssUrl = require('postcss-url');
@@ -15,9 +16,9 @@ const cssnano = require('cssnano');
 module.exports = (ctx) => {
 	const config = {
 		plugins: [
-			/* postcssGlobalData({
-				files: [require.resolve('@teft/viewport/src/media.css')],
-			}), */
+			postcssGlobalData({
+				files: [path.resolve(`${__dirname}/vendor/t2/viewport/src/media.css`)],
+			}),
 			postcssImport,
 			postcssMixins,
 			postcssUrl,


### PR DESCRIPTION
- Use [T2 8.8.0](https://github.com/DekodeInteraktiv/T2/releases/tag/8.8.0).
- Include new extension for Yoast breadcrumb accessibility improvements.
- Use new custom media package from T2 as global data.