### PR TITLE
Upgrade to T2 8.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"roots/bedrock-autoloader": "~1.0.4",
 		"roots/wordpress": "~6.8.0",
 		"symfony/dotenv": "~7.2.0",
-		"t2/t2": "~8.8.2",
+		"t2/t2": "~8.9.0",
 		"wpackagist-plugin/imagify": "~2.2.0",
 		"wpackagist-plugin/spinupwp": "~1.7.1",
 		"wpackagist-plugin/two-factor": "~0.13.0"

--- a/composer.lock
+++ b/composer.lock
@@ -574,15 +574,15 @@
         },
         {
             "name": "t2/admin",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-admin-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-admin-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.2",
-                "t2/icons": "8.8.2"
+                "t2/config": "8.9.0",
+                "t2/icons": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -603,10 +603,10 @@
         },
         {
             "name": "t2/assets",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-assets-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-assets-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -630,17 +630,17 @@
         },
         {
             "name": "t2/block-library",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-block-library-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-block-library-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/blocks": "8.8.2",
-                "t2/config": "8.8.2",
-                "t2/icons": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/blocks": "8.9.0",
+                "t2/config": "8.9.0",
+                "t2/icons": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -661,16 +661,16 @@
         },
         {
             "name": "t2/blocks",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-blocks-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-blocks-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.2",
-                "t2/registry": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/config": "8.9.0",
+                "t2/registry": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -692,10 +692,10 @@
         },
         {
             "name": "t2/config",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-config-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-config-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -719,16 +719,16 @@
         },
         {
             "name": "t2/editor",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-editor-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-editor-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.2",
-                "t2/icons": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/config": "8.9.0",
+                "t2/icons": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -749,17 +749,17 @@
         },
         {
             "name": "t2/extension-library",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.2",
-                "t2/extensions": "8.8.2",
-                "t2/icons": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/config": "8.9.0",
+                "t2/extensions": "8.9.0",
+                "t2/icons": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -780,16 +780,16 @@
         },
         {
             "name": "t2/extensions",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extensions-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extensions-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.8.2",
-                "t2/registry": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/config": "8.9.0",
+                "t2/registry": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -810,14 +810,14 @@
         },
         {
             "name": "t2/icons",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-icons-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-icons-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/utils": "8.8.2"
+                "t2/utils": "8.9.0"
             },
             "type": "package",
             "autoload": {
@@ -838,10 +838,10 @@
         },
         {
             "name": "t2/registry",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-registry-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-registry-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -866,23 +866,23 @@
         },
         {
             "name": "t2/t2",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-t2-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-t2-8.9.0.zip"
             },
             "require": {
-                "t2/admin": "8.8.2",
-                "t2/assets": "8.8.2",
-                "t2/block-library": "8.8.2",
-                "t2/blocks": "8.8.2",
-                "t2/config": "8.8.2",
-                "t2/editor": "8.8.2",
-                "t2/extension-library": "8.8.2",
-                "t2/extensions": "8.8.2",
-                "t2/icons": "8.8.2",
-                "t2/registry": "8.8.2",
-                "t2/utils": "8.8.2"
+                "t2/admin": "8.9.0",
+                "t2/assets": "8.9.0",
+                "t2/block-library": "8.9.0",
+                "t2/blocks": "8.9.0",
+                "t2/config": "8.9.0",
+                "t2/editor": "8.9.0",
+                "t2/extension-library": "8.9.0",
+                "t2/extensions": "8.9.0",
+                "t2/icons": "8.9.0",
+                "t2/registry": "8.9.0",
+                "t2/utils": "8.9.0"
             },
             "type": "wordpress-plugin",
             "license": [
@@ -898,14 +898,14 @@
         },
         {
             "name": "t2/utils",
-            "version": "8.8.2",
+            "version": "8.9.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-utils-8.8.2.zip"
+                "url": "https://t2-packages.teft.io/build/t2-utils-8.9.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/registry": "8.8.2"
+                "t2/registry": "8.9.0"
             },
             "type": "package",
             "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd7599b977831a0146eaee42b87ab406",
+    "content-hash": "f50723b9db5f996f92722a1bd78b6819",
     "packages": [
         {
             "name": "composer/installers",

--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -16,6 +16,7 @@
 		"t2/link-list"
 	],
 	"mu-extensions": [
+		"t2/accessibility-improvements",
 		"t2/allow-svg-uploads",
 		"t2/button-icon",
 		"t2/custom-block-margin",
@@ -36,8 +37,7 @@
 		"t2/reset-admin-dashboard",
 		"t2/search-block-button-icon",
 		"t2/site-health-qa",
-		"t2/wrap-custom-html-block",
-		"t2/yoast-accessibility"
+		"t2/wrap-custom-html-block"
 	],
 	"t2/custom-block-margin": {
 		"version": 3


### PR DESCRIPTION
- Use [T2 8.9.0](https://github.com/DekodeInteraktiv/T2/releases/tag/8.9.0)
- Replace renamed extension `t2/yoast-accessibility` with `t2/accessibility-improvements`