### PR TITLE
Disable editor options for common blocks by default

### DIFF
--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -67,18 +67,6 @@
 					"fontSizes": []
 				}
 			},
-			"core/post-template": {
-				"color": {
-					"palette": []
-				},
-				"spacing": {
-					"blockGap": false
-				},
-				"typography": {
-					"fontFamilies": [],
-					"fontSizes": []
-				}
-			},
 			"core/pullquote": {
 				"border": {
 					"color": false,

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -15,6 +15,7 @@
 					"blockGap": false
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -27,6 +28,7 @@
 					"blockGap": false
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -36,6 +38,7 @@
 					"palette": []
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -45,6 +48,7 @@
 					"palette": []
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -54,6 +58,7 @@
 					"palette": []
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -63,6 +68,7 @@
 					"palette": []
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -81,6 +87,7 @@
 					"blockGap": false
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -93,6 +100,7 @@
 					"blockGap": false
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}
@@ -102,6 +110,7 @@
 					"palette": []
 				},
 				"typography": {
+					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
 				}

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -9,6 +9,7 @@
 					"radius": false
 				},
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"spacing": {
@@ -22,6 +23,7 @@
 			},
 			"core/buttons": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"spacing": {
@@ -35,6 +37,7 @@
 			},
 			"core/list": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"typography": {
@@ -45,6 +48,7 @@
 			},
 			"core/list-item": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"typography": {
@@ -55,6 +59,7 @@
 			},
 			"core/media-text": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"typography": {
@@ -65,6 +70,7 @@
 			},
 			"core/paragraph": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"typography": {
@@ -81,6 +87,7 @@
 					"width": false
 				},
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"spacing": {
@@ -94,6 +101,7 @@
 			},
 			"core/quote": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"spacing": {
@@ -107,6 +115,7 @@
 			},
 			"t2/ingress": {
 				"color": {
+					"gradients": [],
 					"palette": []
 				},
 				"typography": {

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -3,6 +3,128 @@
 	"version": 3,
 	"settings": {
 		"appearanceTools": false,
+		"blocks": {
+			"core/button": {
+				"border": {
+					"radius": false
+				},
+				"color": {
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/buttons": {
+				"color": {
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/list": {
+				"color": {
+					"palette": []
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/list-item": {
+				"color": {
+					"palette": []
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/media-text": {
+				"color": {
+					"palette": []
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/paragraph": {
+				"color": {
+					"palette": []
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/post-template": {
+				"color": {
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/pullquote": {
+				"border": {
+					"color": false,
+					"radius": false,
+					"style": false,
+					"width": false
+				},
+				"color": {
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"core/quote": {
+				"color": {
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"t2/ingress": {
+				"color": {
+					"palette": []
+				},
+				"typography": {
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			}
+		},
+		"border": {
+			"color": false,
+			"radius": false,
+			"style": false,
+			"width": false
+		},
 		"color": {
 			"custom": false,
 			"customDuotone": false,

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -204,6 +204,8 @@
 			"fontWeight": false,
 			"letterSpacing": false,
 			"lineHeight": false,
+			"textAlign": false,
+			"textColumns": false,
 			"textDecoration": false,
 			"textTransform": false,
 			"writingMode": false

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -35,6 +35,20 @@
 					"fontSizes": []
 				}
 			},
+			"core/heading": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"defaultFontSizes": false,
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
 			"core/list": {
 				"color": {
 					"gradients": [],
@@ -79,6 +93,20 @@
 					"fontSizes": []
 				}
 			},
+			"core/post-title": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				},
+				"spacing": {
+					"blockGap": false
+				},
+				"typography": {
+					"defaultFontSizes": false,
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
 			"core/pullquote": {
 				"border": {
 					"color": false,
@@ -113,6 +141,29 @@
 					"fontSizes": []
 				}
 			},
+			"core/table": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				},
+				"typography": {
+					"defaultFontSizes": false,
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
+			"t2/factbox": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				}
+			},
+			"t2/infobox": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				}
+			},
 			"t2/ingress": {
 				"color": {
 					"gradients": [],
@@ -122,6 +173,18 @@
 					"defaultFontSizes": false,
 					"fontFamilies": [],
 					"fontSizes": []
+				}
+			},
+			"t2/statistic-item": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				}
+			},
+			"t2/statistics": {
+				"color": {
+					"gradients": [],
+					"palette": []
 				}
 			}
 		},


### PR DESCRIPTION
Disable typography, color, background, gradient, spacing and border controls for common blocks; Button, List, Media & Text, Paragraph, Quote, Pullquote and T2 Ingress ++

[Theme.json Version 3 Reference](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/)