### PR TITLE
Text underline position under as default

### DIFF
--- a/packages/themes/block-theme/src/view.css
+++ b/packages/themes/block-theme/src/view.css
@@ -9,7 +9,3 @@
 :where([hidden]) {
 	display: none !important;
 }
-
-:root {
-	text-underline-position: under;
-}

--- a/packages/themes/block-theme/src/view.css
+++ b/packages/themes/block-theme/src/view.css
@@ -9,3 +9,7 @@
 :where([hidden]) {
 	display: none !important;
 }
+
+:root {
+	text-underline-position: under;
+}

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -387,7 +387,8 @@
 			"fontFamily": "var(--wp--preset--font-family--body)",
 			"fontSize": "var(--wp--preset--font-size--medium)",
 			"lineHeight": "var(--wp--custom--line-height--15)"
-		}
+		},
+		"css": ":root { text-underline-position: under; }"
 	},
 	"templateParts": [
 		{


### PR DESCRIPTION
Use `text-underline-position: under;` as default to move underline for links lower. (This has previously been done with `text-underline-offset`)

## Before
![before](https://github.com/user-attachments/assets/b152ed8b-29db-4225-bc69-63db997011d9) 

## After
![after](https://github.com/user-attachments/assets/6d4b9d4f-41ec-4e46-82c9-948bc916fe27)

Read more: https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-position