### PR TITLE
Add default support for spacer blocks in Group to reduce start/end padding

### DIFF
--- a/packages/themes/block-theme/src/blocks/core/group.css
+++ b/packages/themes/block-theme/src/blocks/core/group.css
@@ -4,7 +4,16 @@
 }
 
 .wp-block-group.has-background.alignfull {
-	padding: var(--wp--preset--spacing--80);
-	padding-left: var(--wp--style--root--padding-left);
-	padding-right: var(--wp--style--root--padding-right);
+	padding-block: var(--wp--preset--spacing--80);
+	padding-inline-start: var(--wp--style--root--padding-left);
+	padding-inline-end: var(--wp--style--root--padding-right);
+}
+
+/* No start/end padding for groups starting/ending with spacer block */
+.wp-block-group.has-background:has(.t2-spacer:first-child, .wp-block-spacer:first-child) {
+	padding-block-start: unset;
+}
+
+.wp-block-group.has-background:has(.t2-spacer:last-child, .wp-block-spacer:last-child) {
+	padding-block-end: unset;
 }


### PR DESCRIPTION
Using a spacer block (T2 Spacer or core Spacer) as first or last block in a colored group will reset the start/end padding and let the spacer block decide.