### PR TITLE
Feature/FrankenPHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM dunglas/frankenphp
+
+#ENV SERVER_NAME=general.dev
+ENV SERVER_NAME=:80
+
+RUN install-php-extensions \
+	pdo_mysql \
+	gd \
+	intl \
+	zip \
+	opcache \
+	mbstring \
+	mysqli \
+	redis \
+	imagick \
+	exif
+
+# Enable PHP production settings
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Copy the PHP files of your project in the public directory
+#COPY . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  database:
+    image: mariadb:10.5
+    volumes:
+      - "dbdata:/var/lib/mysql"
+      - "./.docker/config/db:/etc/mysql/conf.d"
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-password}
+      MYSQL_DATABASE: ${DB_DATABASE:-wordpress}
+      MYSQL_USER: ${DB_USER:-wordpress}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-password}
+    restart: always
+    command:
+      'mysqld --innodb-flush-method=fsync'
+  redis:
+    image: redis:alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    restart: always
+  web:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443" 
+      - "443:443/udp"
+    volumes:
+      - ./:/app
+      - caddy_data:/data
+      - caddy_config:/config
+    extra_hosts:
+      - "${SITE_URL:-general.dev}:host-gateway"
+    tty: true
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+volumes:
+  dbdata:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
This is a test PR for seeing how WordPress runs with [FrankenPHP](https://frankenphp.dev/), which was recently announced to be [officially supported](https://thephp.foundation/blog/2025/05/15/frankenphp/) by the PHP foundation.

To test this you will need Docker installed locally, and then you can run `docker compose up -d` to start the local environment, and `docker compose down` to stop it. When running you can use `http://localhost` to test the site.

You will need to make a `.env` and will need the following DB credentials-

```
DB_HOST=database
DB_NAME=wordpress
DB_USER=wordpress
DB_PASSWORD=password
DB_PREFIX=wp_
```

This is a work in progress....