### PR TITLE
Increase concurrency to 100% in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,5 +15,6 @@
 			"dependsOn": ["^i18n:make-pot"],
 			"cache": false
 		}
-	}
+	},
+	"concurrency": "100%"
 }


### PR DESCRIPTION
This PR updates the turbo.json configuration to set concurrency to 100%. By allowing full concurrency, we aim to maximize available system resources during builds and task execution, improving overall performance and reducing build times.