### PR TITLE
Fix Domain Path to be compatible with WP 6.8.1

### DIFF
--- a/packages/themes/block-theme/includes/setup-theme.php
+++ b/packages/themes/block-theme/includes/setup-theme.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
  */
 function do_after_setup_theme(): void {
 
-	// Theme text domain.
+	// Theme text domain (NOTE: Consider removing the next line if running WordPress 6.8+).
 	\load_theme_textdomain( 'block-theme', \get_template_directory() . '/languages' );
 
 	// Add theme supports.

--- a/packages/themes/block-theme/includes/setup-theme.php
+++ b/packages/themes/block-theme/includes/setup-theme.php
@@ -24,9 +24,6 @@ defined( 'ABSPATH' ) || exit;
  */
 function do_after_setup_theme(): void {
 
-	// Theme text domain (NOTE: Consider removing the next line if running WordPress 6.8+).
-	\load_theme_textdomain( 'block-theme', \get_template_directory() . '/languages' );
-
 	// Add theme supports.
 	\add_theme_support( 'responsive-embeds' );
 	\add_theme_support( 'post-thumbnails' );

--- a/packages/themes/block-theme/style.css
+++ b/packages/themes/block-theme/style.css
@@ -6,7 +6,7 @@
  * License: GNU General Public License v2 or later
  * License URI: LICENSE
  * Text Domain: block-theme
- * Domain Path: languages
+ * Domain Path: /languages
  * Tags: editor-style, featured-images, full-site-editing, block-patterns
  *
  * This theme, like WordPress, is licensed under the GPL.


### PR DESCRIPTION
Fix Domain Path to be compatible with WP 6.8.1

<!-- The following is a recommended collection of information to include in any Pull Request, please fill it in to the best of your abilities. -->

## Short introduction
The WordPress 6.8 comes with new features for handling i18n as [described here](https://make.wordpress.org/core/2025/03/12/i18n-improvements-6-8/). 

This means we need to make sure the `Text Domain` and the `Domain Path` are correctly set in the theme/plugins headers. Together with @aytac-kokus we traced down that a wrong path set in the theme header will impact the loading of the correct translations files even if we use the `load_theme_textdomain` in the theme.

## Description
<!-- A more thurough description of the problem you are solving, how you solve it, and why. -->

## Steps to test / reproduce
To reproduce:
1. Add previous PB version in a WP 6.8.1 installation
2. Translate theme to NO
3. Set site language to NO
4. Check one template file in the frontend. Translations won't load.

## Screenshots
<!-- Include any relevant screenshots or screen captures showing off how these changes affect the project, if they are visual changes (before and after views are great, and help speed uip the review process) -->

## Checklist
- [ ] I have written unit tests where applicable
- [ ] My code follows the Dekode coding standards
- [ ] I've tested my changes with keyboard and screen readers
- [ ] My code follows the accessibility standards
- [ ] My code is properly documented
- [ ] I've declared any PII (Personally Identifiable Information) for anonymization