### PR TITLE
Remove no longer needed babel config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,11 +16,4 @@ module.exports = {
 		'@wordpress/no-unsafe-wp-apis': 'error',
 		'react-hooks/rules-of-hooks': 'off',
 	},
-	parser: '@babel/eslint-parser',
-	parserOptions: {
-		babelOptions: {
-			presets: ['@wordpress/babel-preset-default'],
-		},
-		requireConfigFile: false,
-	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,7 @@
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^3.0.0",
 				"@wordpress/env": "^10.28.0",
-				"@wordpress/eslint-plugin": "^22.14.0",
 				"@wordpress/scripts": "^30.21.0",
-				"@wordpress/stylelint-config": "^23.20.0",
 				"autoprefixer": "^10.4.21",
 				"browser-sync": "^3.0.4",
 				"cssnano": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
 		"@wordpress/env": "^10.28.0",
-		"@wordpress/eslint-plugin": "^22.14.0",
 		"@wordpress/scripts": "^30.21.0",
-		"@wordpress/stylelint-config": "^23.20.0",
 		"autoprefixer": "^10.4.21",
 		"browser-sync": "^3.0.4",
 		"cssnano": "^7.1.0",


### PR DESCRIPTION
This pull request updates the project's linting configuration by removing the Babel parser and related parser options from the ESLint config, and also removes some WordPress-related linting dependencies from the development dependencies in `package.json`. These changes simplify the project's configuration and reduce dependency bloat.

**Linting configuration simplification:**

* Removed the Babel parser (`@babel/eslint-parser`) and `parserOptions` from `.eslintrc.js`, relying on default ESLint parsing instead.

**Dependency cleanup:**

* Removed `@wordpress/eslint-plugin` and `@wordpress/stylelint-config` from the `devDependencies` in `package.json`, reducing unnecessary WordPress-specific linting dependencies.