### PR TITLE
Replace use of T2 Footer block in default footer with template part

### DIFF
--- a/packages/themes/block-theme/parts/footer.html
+++ b/packages/themes/block-theme/parts/footer.html
@@ -1,1 +1,35 @@
-<!-- wp:t2/footer { "twitterUrl": "#", "instagramUrl": "#", "facebookUrl": "#"} /-->
+<!-- wp:group {"align":"full","backgroundColor":"foreground","color":"background","className":"site-footer-group","layout":{"type":"constrained"}} -->
+<div
+	class="wp-block-group is-layout-constrained alignfull has-foreground-background-color has-background-color has-background site-footer-group"
+>
+	<!-- wp:site-logo {"align":"wide","isLink":false} /-->
+
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"width":"50%"} -->
+		<div class="wp-block-column" style="flex-basis: 50%">
+			<!-- wp:paragraph -->
+			<p>
+				Cras mattis consectetur purus sit amet fermentum. Cum sociis natoque penatibus et magnis dis parturient
+				montes, nascetur ridiculus mus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
+				Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis: 25%">
+			<!-- wp:t2/nav-menu {"container":"","depth":1,"theme_location":"main-menu"} /-->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis: 25%">
+			<!-- wp:t2/nav-menu {"container":"","depth":1,"theme_location":"main-menu"} /-->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/packages/themes/block-theme/parts/footer.html
+++ b/packages/themes/block-theme/parts/footer.html
@@ -1,8 +1,10 @@
-<!-- wp:group {"align":"full","backgroundColor":"foreground","color":"background","className":"site-footer-group","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","className":"is-layout-constrained site-footer-group","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained"}} -->
 <div
-	class="wp-block-group is-layout-constrained alignfull has-foreground-background-color has-background-color has-background site-footer-group"
+	class="wp-block-group alignfull is-layout-constrained site-footer-group has-background-color has-primary-background-color has-text-color has-background has-link-color"
 >
-	<!-- wp:site-logo {"align":"wide","isLink":false} /-->
+	<!-- wp:site-logo {"isLink":false,"align":"wide"} /-->
+
+	<!-- wp:t2/spacer {"gap":"50"} /-->
 
 	<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide">

--- a/packages/themes/block-theme/parts/footer.html
+++ b/packages/themes/block-theme/parts/footer.html
@@ -1,6 +1,6 @@
-<!-- wp:group {"align":"full","className":"is-layout-constrained site-footer-group","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","className":"is-layout-constrained","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"type":"constrained"}} -->
 <div
-	class="wp-block-group alignfull is-layout-constrained site-footer-group has-background-color has-primary-background-color has-text-color has-background has-link-color"
+	class="wp-block-group alignfull is-layout-constrained has-background-color has-primary-background-color has-text-color has-background has-link-color"
 >
 	<!-- wp:site-logo {"isLink":false,"align":"wide"} /-->
 

--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -12,7 +12,8 @@
 		"t2/featured-template-post",
 		"t2/header-horizontal",
 		"t2/ingress",
-		"t2/link-list"
+		"t2/link-list",
+		"t2/nav-menu"
 	],
 	"mu-extensions": [
 		"t2/accessibility-improvements",

--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -10,7 +10,6 @@
 		"t2/featured-query-post",
 		"t2/featured-single-post",
 		"t2/featured-template-post",
-		"t2/footer",
 		"t2/header-horizontal",
 		"t2/ingress",
 		"t2/link-list"

--- a/packages/themes/block-theme/templates/404.html
+++ b/packages/themes/block-theme/templates/404.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
@@ -13,4 +13,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","className":"footer-wrapper"} /-->

--- a/packages/themes/block-theme/templates/index.html
+++ b/packages/themes/block-theme/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
 <!-- wp:query {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-query">
@@ -22,4 +22,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","className":"footer-wrapper"} /-->

--- a/packages/themes/block-theme/templates/search.html
+++ b/packages/themes/block-theme/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
 <!-- wp:query {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-query">
@@ -23,4 +23,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","className":"footer-wrapper"} /-->

--- a/packages/themes/block-theme/templates/singular.html
+++ b/packages/themes/block-theme/templates/singular.html
@@ -1,3 +1,3 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 <!-- wp:post-content {"tagName":"main","align":"full","layout":{"type":"constrained"}} /-->
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","className":"footer-wrapper"} /-->


### PR DESCRIPTION
Replace the [deprecated T2 Footer block](https://github.com/DekodeInteraktiv/T2/pull/5378) with simple and easy customizable footer based on existing core and T2 blocks. A basic out-of-the-box template that can easily be extended or changed in project. Template contains site logo, a text paragraph and two menus _(that need to be linked to the project menu locations)_.

<img width="1491" height="1242" alt="Screenshot 2025-09-30 at 13 31 57" src="https://github.com/user-attachments/assets/e7e21d9b-9fd7-45f7-96f8-0eb5f804a18a" />
