### PR TITLE
Disable color and typography options for T2 Simple Media & Text by default

### DIFF
--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -189,6 +189,17 @@
 					"fontSizes": []
 				}
 			},
+			"t2/simple-media-text": {
+				"color": {
+					"gradients": [],
+					"palette": []
+				},
+				"typography": {
+					"defaultFontSizes": false,
+					"fontFamilies": [],
+					"fontSizes": []
+				}
+			},
 			"t2/statistic-item": {
 				"color": {
 					"gradients": [],


### PR DESCRIPTION
… same as we do for core Media & Text.