### PR TITLE
Add TypeScript configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
 				"postcss-nesting": "^13.0.2",
 				"postcss-url": "^10.1.3",
 				"prettier": "^3.6.2",
-				"turbo": "^2.5.6"
+				"turbo": "^2.5.6",
+				"typescript": "^5.9.3"
 			},
 			"engines": {
 				"node": "20",
@@ -24220,12 +24221,11 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"postcss-nesting": "^13.0.2",
 		"postcss-url": "^10.1.3",
 		"prettier": "^3.6.2",
-		"turbo": "^2.5.6"
+		"turbo": "^2.5.6",
+		"typescript": "^5.9.3"
 	},
 	"scripts": {
 		"create-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block",
@@ -49,6 +50,7 @@
 		"lint:js": "wp-scripts lint-js",
 		"lint:format": "prettier --check .",
 		"lint-staged": "lint-staged",
+		"type-check": "tsc --pretty --noEmit",
 		"browsersync:start": "node browsersync.config.js",
 		"wp-env": "wp-env"
 	},

--- a/packages/themes/block-theme/tsconfig.json
+++ b/packages/themes/block-theme/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"jsx": "react-jsx",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowJs": true,
+		"noEmit": true
+	},
+	"include": ["packages/**/*"],
+	"exclude": ["node_modules", "vendor", "build"]
+}


### PR DESCRIPTION
Added root tsconfig.json and a package-specific tsconfig.json for block-theme. Updated TypeScript to version 5.9.3 and added it as a dev dependency. Introduced a 'type-check' npm script for type checking.